### PR TITLE
chore: 대시보드 헤더 레이아웃 구조(UI), css 생성

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,17 @@
-import { RouterProvider } from 'react-router-dom'
-import { router } from './routes'
+// import { RouterProvider } from 'react-router-dom'
+// import { router } from './routes'
+
+import { Header } from "./components"
 
 function App() {
-  return <RouterProvider router={router} />
+  // return <RouterProvider router={router} />
+
+  // Header 컴포넌트 작업 중
+  return (
+    <div>
+      <Header />
+    </div>
+  )
 }
 
 export default App

--- a/frontend/src/components/common/header/header.module.css
+++ b/frontend/src/components/common/header/header.module.css
@@ -1,0 +1,80 @@
+.header{
+  display: flex;
+  flex-flow: nowrap row;
+  justify-content: space-between;
+  align-items: center;
+  inline-size: 100%;
+  max-inline-size: 1604px;
+  block-size: 70px;
+  margin: 0;
+  padding: 30px;
+  text-align: left;
+  font-family: 'Pretendard variable';
+ 
+    .menu_name{
+      margin: 0;
+      padding: 0;
+      font-size: var(--big-title);
+      font-weight: var(--Exbd);
+    }
+
+    .sub_title{
+      margin-block-start: 10px;
+      font-size: var(--sub-title);
+      color: var(--error-gray)
+    }
+  
+  .user_profile{
+    display: flex;
+    flex-flow: nowrap row;
+    align-items: center;
+    gap: 10px;
+
+    .user_icons{
+      display: flex;
+      flex-flow: nowrap row;
+      align-items: center;
+
+      .user_first_name{
+        display: flex;
+        flex-flow: nowrap row;
+        justify-content: center;
+        align-items: center;
+        inline-size: 40px;
+        block-size: 40px;
+        margin-inline-end: 10px;
+        font-size: var(--sub-title);
+        font-weight: var(--Bd);
+        color: var(--white);
+        border-radius: 100%;
+        background-color: var(--default-orange);
+      }
+    }
+
+    .user_status{
+      margin-inline-end: 30px;
+
+      .account_name{
+        font-size: var(--sub-title);
+        font-weight: var(--Bd);
+        color: var(--default-black)
+      }
+
+      .account_eng{
+        font-size: var(--sm-title);
+        color: var(--error-gray)
+      }
+    }
+
+    .logout_button{
+      inline-size: 70px;
+      block-size: 40px;
+      font-size: var(--sm-title);
+      background-color: var(--border-gray);
+      border: none;
+      border-radius: var(--border-radius-md);
+      cursor: pointer;
+    }
+  }
+
+}

--- a/frontend/src/components/common/header/header.tsx
+++ b/frontend/src/components/common/header/header.tsx
@@ -1,0 +1,27 @@
+import S from './header.module.css'
+
+
+function Header(){
+  return(
+    <header className={S.header}>
+      <div className={S.title}>
+        <h1 className={S.menu_name}>대시보드</h1>
+        <p className={S.sub_title}>환영합니다.</p>
+      </div>
+      <div className={S.user_profile}>
+        <div className={S.user_icons}>
+          <span className={S.user_first_name}>
+            관
+          </span>
+          <div className={S.user_status}>
+            <p className={S.account_name}>관리자</p>
+            <p className={S.account_eng}>LikeLion_admin</p>
+          </div>
+        </div>
+      <button className={S.logout_button}>로그아웃</button>
+      </div>
+    </header>
+  )
+}
+
+export default Header;

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -1,0 +1,1 @@
+export {default as Header} from './common/header/header'

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -51,11 +51,10 @@
 }
 
 #root {
-  width: 1126px;
+  width: 1920px;
   max-width: 100%;
   margin: 0 auto;
   text-align: center;
-  border-inline: 1px solid var(--border);
   min-height: 100svh;
   display: flex;
   flex-direction: column;
@@ -64,6 +63,7 @@
 
 body {
   margin: 0;
+   overflow-x: hidden;
 }
 
 h1,


### PR DESCRIPTION
< 대시보드 공통 타이틀 컴포넌트 >

- 메뉴 타이틀
- 서브타이틀(응원문구, 인삿말 들어가는 영역)
- 프로필 아이콘(이미지 변경 없을 시 이름의 성으로만 표시)
- 계정주 이름
- 계정 영어 라벨
- 로그아웃 버튼