### PR TITLE
style: focus, hover 상태 컬러값 추가

### DIFF
--- a/frontend/src/styles/theme/theme.css
+++ b/frontend/src/styles/theme/theme.css
@@ -38,6 +38,14 @@
   --error-gray: #aaaaaa;
   --border-gray: #dddddd;
   --grad-orange: linear-gradient(135deg, #ff6000 0%, #FFBB28 100%);
+  
+
+  /* 상태에 따른 버튼 색상 컬러 */
+  --focus: #cccccc;
+  --hover-orange: #FF2600;
+  --hover-black: #000000;
+  --hover-gray: #777777;
+  --hover-border: #555555;
 }
 
 /* margin, padding*/


### PR DESCRIPTION
<img width="736" height="308" alt="image" src="https://github.com/user-attachments/assets/935d50f3-9788-4ada-a2ef-9e79e095d564" />


누락된 공통 CSS focus, hover 상태 컬러값 추가