### PR TITLE
feat: 공통 컴포넌트 카운트 카드 생성 및 샘플 페이지 내 적용

### DIFF
--- a/frontend/src/components/common/countCard/CountCard.tsx
+++ b/frontend/src/components/common/countCard/CountCard.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from 'react'
+import S from './CountCard.module.css'
+
+interface CountCardProps {
+  label: string
+  value: number | string
+  unit?: string
+  icon: ReactNode
+  variant?: 'gray' | 'green' | 'yellow' | 'red' | 'orange'
+}
+
+export default function CountCard({ label, value, unit, icon, variant = 'gray' }: CountCardProps) {
+  return (
+    <div className={`${S.card} ${S[variant]}`}>
+      <div className={S['icon_box']}>{icon}</div>
+
+      <p className={S.label}>{label}</p>
+
+      <strong className={S.value}>
+        {value}
+        {unit && <span className={S.unit}> {unit}</span>}
+      </strong>
+    </div>
+  )
+}

--- a/frontend/src/components/common/countCard/countCard.module.css
+++ b/frontend/src/components/common/countCard/countCard.module.css
@@ -1,0 +1,87 @@
+.card {
+  --point-color: #666666;
+  --icon-bg-color: #f1f3f5;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+
+  inline-size: 176px;
+  block-size: 138px;
+  padding: 20px;
+
+  background-color: #ffffff;
+  border: 2px solid var(--point-color);
+  border-radius: 12px;
+}
+
+.gray {
+  --point-color: #666666;
+  --icon-bg-color: #f1f3f5;
+}
+
+.green {
+  --point-color: #00a84f;
+  --icon-bg-color: #e6f7ef;
+}
+
+.yellow {
+  --point-color: #f5b400;
+  --icon-bg-color: #fff7db;
+}
+
+.red {
+  --point-color: #ff1f1f;
+  --icon-bg-color: #ffe8e8;
+}
+
+.orange {
+  --point-color: #ff5a00;
+  --icon-bg-color: #fff0e6;
+}
+
+.icon_box {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  inline-size: 50px;
+  block-size: 50px;
+
+  margin-block-end: 12px;
+
+  color: var(--point-color);
+  background-color: var(--icon-bg-color);
+  border-radius: 9px;
+}
+
+.icon_box svg {
+  inline-size: 30px;
+  block-size: 30px;
+
+  color: currentcolor;
+  stroke: currentcolor;
+}
+
+.label {
+  margin-block-end: 6px;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--point-color);
+  text-align: left;
+}
+
+.value {
+  font-size: 32px;
+  font-weight: 800;
+  line-height: 1.1;
+  color: var(--point-color);
+}
+
+.unit {
+  margin-inline-start: 2px;
+  font-size: 14px;
+  font-weight: 500;
+  color: #555555;
+}

--- a/frontend/src/pages/sample/Samplepage.tsx
+++ b/frontend/src/pages/sample/Samplepage.tsx
@@ -1,8 +1,10 @@
 import DatePicker from '../../components/common/datePicker'
 import { Header, Button } from '../../components'
-import { Plus, Search, Trash, SquarePen, X, Check, Key } from 'lucide-react'
-import { useState } from 'react'
+import { Plus, Search, Trash, SquarePen, X, Check, Key, Clock } from 'lucide-react'
+import { useEffect, useState } from 'react'
 import Sidebar from '../../components/common/sidebar/Sidebar'
+import CountCard from '../../components/common/countCard/CountCard'
+import { UserCheck, UserX, TrendingUp, ScrollText } from 'lucide-react'
 
 export default function LoginPage() {
   {
@@ -17,6 +19,25 @@ export default function LoginPage() {
   }
   {
     /* //달력컴포넌트: Datepicker */
+  }
+
+  {
+    /* 카운트 카드 컴포넌트 */
+  }
+  const countCardData = {
+    attendaceRate: 92.74,
+    presentCount: 230,
+    lateCount: 16,
+    absentCount: 2,
+    leavePendingCount: 14,
+  }
+
+  // useEffect(( => {
+  //   나중에 연결
+  // },[]))
+
+  {
+    /* //카운트 카드 컴포넌트 */
   }
 
   return (
@@ -54,11 +75,11 @@ export default function LoginPage() {
         <Trash size={16} />
         공지사항 삭제
       </Button>
-      <Button variant="dark" size='md'>
+      <Button variant="dark" size="md">
         <Search size={16} />
         검색
       </Button>
-      <Button variant="dark" size='lg'>
+      <Button variant="dark" size="lg">
         <Key size={16} />
         비밀번호 변경
       </Button>
@@ -93,6 +114,47 @@ export default function LoginPage() {
         </div>
       </div>
       {/* //사이드바 컴포넌트 */}
+
+      {/* 카운트 카드 컴포넌트 */}
+      <h3 style={{ textAlign: 'left' }}>4. 카운트 카드 컴포넌트 샘플</h3>
+      <div style={{ display: 'flex', gap: '16px' }}>
+        <CountCard
+          label="오늘의 출석률"
+          value={countCardData.attendaceRate}
+          unit="%"
+          icon={<TrendingUp />}
+          variant="gray"
+        />
+        <CountCard
+          label="출석완료"
+          value={countCardData.presentCount}
+          unit="명"
+          icon={<UserCheck />}
+          variant="green"
+        />
+        <CountCard
+          label="지각인원"
+          value={countCardData.lateCount}
+          unit="명"
+          icon={<Clock />}
+          variant="yellow"
+        />
+        <CountCard
+          label="결석인원"
+          value={countCardData.absentCount}
+          unit="명"
+          icon={<UserX />}
+          variant="red"
+        />
+        <CountCard
+          label="휴가승인대기"
+          value={countCardData.leavePendingCount}
+          unit="명"
+          icon={<ScrollText />}
+          variant="orange"
+        />
+      </div>
+      {/* //카운트 카드 컴포넌트 */}
     </div>
   )
 }


### PR DESCRIPTION
## 📌 개요

- 카운트 카드 구현

## 💻 작업 사항

- CountCard 공통 컴포넌트 생성
- CountCard 스타일(CSS Module) 구현
- 아이콘 및 variant(색상) props 적용
- 샘플 페이지에 CountCard 컴포넌트 적용 및 UI 확인

## 📸 스크린샷 (선택)

<img width="1540" height="304" alt="image" src="https://github.com/user-attachments/assets/0cde7441-93ce-4b76-98ef-da01910dc339" />
  
## 💡 관련 Issue

Closes #19

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #)
- [x] 불필요한 console.log를 제거했습니다.
- [x] 사용하지 않는 코드/파일을 정리했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 기능이 정상 동작하는지 확인했습니다.
