### PR TITLE
chore: 공통 컴포넌트 페이지 네이션 구현 및 샘플 페이지 내 적용

### DIFF
--- a/frontend/src/components/common/pagination/Pagination.tsx
+++ b/frontend/src/components/common/pagination/Pagination.tsx
@@ -1,0 +1,74 @@
+import S from './Pagination.module.css'
+
+interface PaginationProps {
+  currentPage: number
+  totalPages: number
+  onPageChange: (page: number) => void
+}
+
+export default function Pagination({ currentPage, totalPages, onPageChange }: PaginationProps) {
+  const getPages = () => {
+    if (totalPages <= 5) {
+      return Array.from({ length: totalPages }, (_, index) => index + 1)
+    }
+
+    if (currentPage === 1) {
+      return [1, 2, 3, '...', totalPages]
+    }
+
+    if (currentPage === 2) {
+      return [1, 2, 3, '...', totalPages]
+    }
+
+    if (currentPage === 3) {
+      return [1, 2, 3, 4, '...', totalPages]
+    }
+
+    if (currentPage >= totalPages - 2) {
+      return [1, '...', totalPages - 3, totalPages - 2, totalPages - 1, totalPages]
+    }
+
+    return [1, '...', currentPage - 1, currentPage, currentPage + 1, '...', totalPages]
+  }
+
+  const pages = getPages()
+
+  return (
+    <nav className={S.pagination}>
+      <button
+        type="button"
+        className={S.pageButton}
+        onClick={() => onPageChange(currentPage - 1)}
+        disabled={currentPage === 1}
+      >
+        이전
+      </button>
+
+      {pages.map((page, index) =>
+        page === '...' ? (
+          <span key={`ellipsis-${index}`} className={S.ellipsis}>
+            ...
+          </span>
+        ) : (
+          <button
+            key={`page-${page}`}
+            type="button"
+            className={`${S.pageButton} ${currentPage === page ? S.active : ''}`}
+            onClick={() => onPageChange(Number(page))}
+          >
+            {page}
+          </button>
+        ),
+      )}
+
+      <button
+        type="button"
+        className={S.pageButton}
+        onClick={() => onPageChange(currentPage + 1)}
+        disabled={currentPage === totalPages}
+      >
+        다음
+      </button>
+    </nav>
+  )
+}

--- a/frontend/src/components/common/pagination/index.ts
+++ b/frontend/src/components/common/pagination/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Pagination'

--- a/frontend/src/components/common/pagination/pagination.module.css
+++ b/frontend/src/components/common/pagination/pagination.module.css
@@ -1,0 +1,54 @@
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.pageButton,
+.ellipsis {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  inline-size: auto;
+  min-inline-size: 32px;
+  block-size: 32px;
+  padding-inline: 8px;
+
+  font-size: 13px;
+  font-weight: 500;
+  color: #111827;
+
+  background-color: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  box-shadow: 0 1px 1px rgb(0 0 0 / 4%);
+}
+
+.pageButton {
+  cursor: pointer;
+}
+
+.pageButton:hover:not(:disabled):not(.active) {
+  background-color: #f9fafb;
+}
+
+.pageButton:disabled {
+  cursor: not-allowed;
+
+  color: #9ca3af;
+
+  background-color: #f9fafb;
+}
+
+.active {
+  color: #ffffff;
+
+  background-color: #ff5a00;
+  border-color: #ff5a00;
+}
+
+.ellipsis {
+  cursor: default;
+}

--- a/frontend/src/pages/sample/Samplepage.tsx
+++ b/frontend/src/pages/sample/Samplepage.tsx
@@ -1,14 +1,27 @@
 import DatePicker from '../../components/common/datePicker'
 import Sidebar from '../../components/common/sidebar/Sidebar'
-import SearchBar from '../../components/common/search/search' 
+import SearchBar from '../../components/common/search/search'
 import ComboBox from '../../components/common/comboBox/comboBox'
 import { Header, Button } from '../../components'
-import { Plus, Search, Trash, SquarePen, X, Check, Key, Clock } from 'lucide-react'
+import {
+  Plus,
+  Search,
+  Trash,
+  SquarePen,
+  X,
+  Check,
+  Key,
+  Clock,
+  UserCheck,
+  UserX,
+  TrendingUp,
+  ScrollText,
+} from 'lucide-react'
 import { useEffect, useState } from 'react'
 import CustomComboBox from '../../components/common/comboBox/customComboBox'
 
 import CountCard from '../../components/common/countCard/CountCard'
-import { UserCheck, UserX, TrendingUp, ScrollText } from 'lucide-react'
+import Pagination from '../../components/common/pagination'
 
 export default function LoginPage() {
   {
@@ -39,9 +52,16 @@ export default function LoginPage() {
   // useEffect(( => {
   //   나중에 연결
   // },[]))
-
   {
     /* //카운트 카드 컴포넌트 */
+  }
+
+  {
+    /* 페이지네이션 컴포넌트 */
+  }
+  const [currentPage, setCurrentPage] = useState(1)
+  {
+    /* //페이지네이션 컴포넌트 */
   }
 
   return (
@@ -160,13 +180,24 @@ export default function LoginPage() {
       </div>
       {/* //카운트 카드 컴포넌트 */}
 
-
+      {/* 검색바/콤보박스 컴포넌트 샘플 */}
       <h3 style={{ textAlign: 'left' }}>5. 검색바/콤보박스 컴포넌트 샘플</h3>
-      
+
       <ComboBox options={['옵션 1', '옵션 2', '옵션 3']} placeholder="콤보박스 선택" />
-      <CustomComboBox options={['커스텀 옵션 1', '커스텀 옵션 2', '커스텀 옵션 3']} placeholder="커스텀 콤보박스 선택" />
-      <SearchBar placeholder='강의검색'/>
-      <SearchBar placeholder='강의명을 입력하세요'/>
+      <CustomComboBox
+        options={['커스텀 옵션 1', '커스텀 옵션 2', '커스텀 옵션 3']}
+        placeholder="커스텀 콤보박스 선택"
+      />
+      <SearchBar placeholder="강의검색" />
+      <SearchBar placeholder="강의명을 입력하세요" />
+      {/* //검색바/콤보박스 컴포넌트 샘플 */}
+
+      {/* 페이지네이션 컴포넌트 */}
+      <h3 style={{ textAlign: 'left' }}>5. 페이지네이션 컴포넌트 샘플</h3>
+      <div style={{ display: 'flex', gap: '16px' }}>
+        <Pagination currentPage={currentPage} totalPages={10} onPageChange={setCurrentPage} />
+      </div>
+      {/* //페이지네이션 컴포넌트 */}
     </div>
   )
 }


### PR DESCRIPTION
## 📌 개요

- 공통 컴포넌트 페이지네이션 구현

## 💻 작업 사항

- Pagination 공통 컴포넌트 생성
- 현재 페이지 기준으로 페이지 목록 동적 생성 로직 구현
- 앞/뒤 페이지 및 ellipsis(...) 처리
- 이전/다음 버튼 기능 구현 및 disabled 상태 처리
- 페이지 이동(onPageChange) 핸들링 구현


## 📸 스크린샷 (선택)

<img width="555" height="126" alt="image" src="https://github.com/user-attachments/assets/5df83fa6-7368-4dcb-a0c4-a27955210c34" />

  
## 📎 참고 사항 (선택)


  
## 💡 관련 Issue

Closes #32 

## ✅ 체크리스트

- [ ] 관련 이슈를 연결했습니다. (Closes #)
- [ ] 불필요한 console.log를 제거했습니다.
- [ ] 사용하지 않는 코드/파일을 정리했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 기능이 정상 동작하는지 확인했습니다.
