### PR TITLE
feat: 카운트 카드 API 연결 및 import 경로 @alias로 변경

### DIFF
--- a/frontend/src/api/axiosInstance.ts
+++ b/frontend/src/api/axiosInstance.ts
@@ -1,8 +1,0 @@
-import axios from 'axios'
-
-export const axiosInstance = axios.create({
-  baseURL: 'https://final-project-team1.onrender.com',
-  headers: {
-    'Content-Type': 'application/json',
-  },
-})

--- a/frontend/src/pages/admin/dashboard/api/dashboardApi.ts
+++ b/frontend/src/pages/admin/dashboard/api/dashboardApi.ts
@@ -1,4 +1,4 @@
-import { axiosInstance } from '../../../../api/axiosInstance'
+import { api } from '@/api/axios'
 
 export interface AdminDashboardData {
   studentCount: number
@@ -11,11 +11,10 @@ export interface AdminDashboardData {
 }
 
 export async function getAdminDashboardSummary() {
-  const response = await axiosInstance.get<{
-    success: boolean
-    message: string
-    data: AdminDashboardData
-  }>('/api/admin/dashboard')
+  const response = await api.get('/api/admin/dashboard')
+
+  console.log('전체 응답:', response)
+  console.log('response.data:', response.data)
 
   return response.data.data
 }

--- a/frontend/src/pages/sample/Samplepage.tsx
+++ b/frontend/src/pages/sample/Samplepage.tsx
@@ -27,7 +27,7 @@ import S from '../../components/common/table/table.module.css'
 import {
   getAdminDashboardSummary,
   type AdminDashboardData,
-} from '../admin/dashboard/api/dashboardApi'
+} from '@/pages/admin/dashboard/api/dashboardApi'
 
 {
   /* 테이블 컴포넌트 */
@@ -176,7 +176,6 @@ export default function LoginPage() {
     /* 카운트 카드 컴포넌트 */
   }
   const [summary, setSummary] = useState<AdminDashboardData | null>(null)
-
 
   useEffect(() => {
     const fetchSummary = async () => {
@@ -565,7 +564,6 @@ export default function LoginPage() {
       {/* 검색바/콤보박스 컴포넌트 샘플 */}
       <h3 style={{ textAlign: 'left' }}>5. 검색바/콤보박스 컴포넌트 샘플</h3>
 
-     
       <ComboBox
         options={['커스텀 옵션 1', '커스텀 옵션 2', '커스텀 옵션 3']}
         placeholder="커스텀 콤보박스 선택"


### PR DESCRIPTION
## 📌 개요

- PR 내용을 간단히 요약해주세요.

## 🔁 변경 사항 (재PR 시 작성)

- 관리자 대시보드 API 연결
- axios baseURL을 환경변수(.env)로 설정
- import 경로를 상대경로에서 @ alias 방식으로 변경

## 📸 스크린샷 (선택)


  
## 📎 참고 사항 (선택)


  
## 💡 관련 Issue

Closes #32 

## ✅ 체크리스트

- [ ] 관련 이슈를 연결했습니다. (Closes #)
- [ ] 불필요한 console.log를 제거했습니다.
- [ ] 사용하지 않는 코드/파일을 정리했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 기능이 정상 동작하는지 확인했습니다.
