### PR TITLE
refactor: 샘플페이지 내 상대경로 import를 @ alias 방식으로 변경

### DIFF
--- a/frontend/src/pages/sample/Samplepage.tsx
+++ b/frontend/src/pages/sample/Samplepage.tsx
@@ -1,8 +1,8 @@
-import DatePicker from '../../components/common/datePicker'
-import Sidebar from '../../components/common/sidebar/Sidebar'
-import SearchBar from '../../components/common/search/search'
-import ComboBox from '../../components/common/comboBox/customComboBox'
-import { Header, Button } from '../../components'
+import DatePicker from '@/components/common/datePicker'
+import Sidebar from '@/components/common/sidebar/Sidebar'
+import SearchBar from '@/components/common/search/search'
+import ComboBox from '@/components/common/comboBox/customComboBox'
+import { Header, Button } from '@/components'
 import {
   Plus,
   Search,
@@ -19,11 +19,11 @@ import {
 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 
-import CountCard from '../../components/common/countCard/CountCard'
-import Pagination from '../../components/common/pagination'
+import CountCard from '@/components/common/countCard/CountCard'
+import Pagination from '@/components/common/pagination'
 
-import Table, { type TableColumn } from '../../components/common/table'
-import S from '../../components/common/table/table.module.css'
+import Table, { type TableColumn } from '@/components/common/table'
+import S from '@/components/common/table/table.module.css'
 import {
   getAdminDashboardSummary,
   type AdminDashboardData,


### PR DESCRIPTION
## 📌 개요

- 샘플페이지 import 경로를 @ alias 방식으로 변경했

## 💻 작업 사항

- 샘플페이지 import 경로를 @ alias 방식으로 변경
- 상대경로(../../)를 @/ 기준으로 수정

## 📸 스크린샷 (선택)

<img width="713" height="167" alt="image" src="https://github.com/user-attachments/assets/9481b41f-c5e1-498e-8ce1-b2ade14faa37" />
  
## 📎 참고 사항 (선택)

## 💡 관련 Issue

Closes #42 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #)
- [x] 불필요한 console.log를 제거했습니다.
- [x] 사용하지 않는 코드/파일을 정리했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
