### PR TITLE
feat: 관리자 대시보드 UI 구성 및 공통 컴포넌트 적용

### DIFF
--- a/frontend/src/components/common/countCard/countCard.module.css
+++ b/frontend/src/components/common/countCard/countCard.module.css
@@ -7,8 +7,8 @@
   justify-content: center;
   align-items: flex-start;
 
-  inline-size: 176px;
-  block-size: 138px;
+  inline-size: 100%;
+  block-size: 180px;
   padding: 20px;
 
   background-color: #ffffff;
@@ -49,7 +49,7 @@
   inline-size: 50px;
   block-size: 50px;
 
-  margin-block-end: 12px;
+  margin-block-end: 16px;
 
   color: var(--point-color);
   background-color: var(--icon-bg-color);
@@ -65,7 +65,7 @@
 }
 
 .label {
-  margin-block-end: 6px;
+  margin-block-end: 8px;
   font-size: 16px;
   font-weight: 600;
   color: var(--point-color);

--- a/frontend/src/pages/admin/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/admin/dashboard/DashboardPage.tsx
@@ -1,5 +1,203 @@
-function DashboardPage() {
-  return <div>대시보드</div>
+import AdminLayout from '@/pages/sample/AdminLayout'
+import { useEffect, useState } from 'react'
+import { Clock, ScrollText, TrendingUp, UserCheck, UserX, Check, X } from 'lucide-react'
+
+import CountCard from '@/components/common/countCard/CountCard'
+import {
+  getAdminDashboardSummary,
+  type AdminDashboardData,
+} from '@/pages/admin/dashboard/api/dashboardApi'
+// import AttendanceStatusChart from './components/AttendanceStatusChart'
+import SystemNoticeList from './components/NoticeList'
+import Table, { type TableColumn } from '@/components/common/table'
+import { Button } from '@/components'
+import S from '@/pages/admin/dashboard/styles/dashboard.module.css'
+
+import Pagination from '@/components/common/pagination/Pagination'
+
+type VacationType = '병결' | '공결' | '개인사유'
+
+type Vacation = {
+  name: string
+  studentNo: string
+  vacationType: VacationType
+  period: string
 }
 
-export default DashboardPage
+const vacationTypeMap = {
+  병결: {
+    label: '병결',
+    className: S.vacationSick,
+  },
+  공결: {
+    label: '공결',
+    className: S.vacationOfficial,
+  },
+  개인사유: {
+    label: '개인사유',
+    className: S.vacationPersonal,
+  },
+}
+
+const vacationData: Vacation[] = [
+  {
+    name: '김민수',
+    studentNo: '2024001',
+    vacationType: '병결',
+    period: '00.00 - 00.00',
+  },
+  {
+    name: '황재호',
+    studentNo: '2024001',
+    vacationType: '공결',
+    period: '00.00 - 00.00',
+  },
+  {
+    name: '정호영',
+    studentNo: '2024001',
+    vacationType: '개인사유',
+    period: '00.00 - 00.00',
+  },
+]
+
+export default function AdminDashboardPage() {
+  const [summary, setSummary] = useState<AdminDashboardData | null>(null)
+  const [currentPage, setCurrentPage] = useState(1)
+
+  useEffect(() => {
+    const fetchSummary = async () => {
+      try {
+        const data = await getAdminDashboardSummary()
+        setSummary(data)
+      } catch (error) {
+        console.error(error)
+      }
+    }
+
+    fetchSummary()
+  }, [])
+
+  const handleApprove = (row: Vacation) => {
+    console.log('승인', row)
+  }
+
+  const handleReject = (row: Vacation) => {
+    console.log('반려', row)
+  }
+
+  const pageSize = 12
+  const totalCount = 248
+  const totalPages = Math.ceil(totalCount / pageSize)
+
+  const vacationColumns: TableColumn<Vacation>[] = [
+    {
+      key: 'name',
+      header: '신청자',
+      render: (row) => (
+        <div className={S.nameBox}>
+          <span className={S.circle}>{row.name[0]}</span>
+          <span className={S.tit}>{row.name}</span>
+        </div>
+      ),
+    },
+    { key: 'studentNo', header: '학번' },
+    {
+      key: 'vacationType',
+      header: '휴가종류',
+      render: (row) => {
+        const vacation = vacationTypeMap[row.vacationType]
+
+        return <span className={`${S.statusBadge} ${vacation.className}`}>{vacation.label}</span>
+      },
+    },
+    { key: 'period', header: '기간' },
+    {
+      key: 'action',
+      header: '처리',
+      render: (row) => (
+        <div className={S.actionBox}>
+          <Button type="button" variant="active" onClick={() => handleApprove(row)}>
+            <Check size={16} />
+            승인
+          </Button>
+
+          <Button type="button" variant="inactive" onClick={() => handleReject(row)}>
+            <X size={16} />
+            반려
+          </Button>
+        </div>
+      ),
+    },
+  ]
+
+  return (
+    <AdminLayout>
+      <div className={S.dashboard}>
+        <section className={S.cardSection}>
+          <CountCard
+            label="오늘의 출석률"
+            value={summary?.attendanceRate ?? 0}
+            unit="%"
+            icon={<TrendingUp />}
+            variant="gray"
+          />
+          <CountCard
+            label="출석완료"
+            value={summary?.presentCount ?? 0}
+            unit="명"
+            icon={<UserCheck />}
+            variant="green"
+          />
+          <CountCard
+            label="지각인원"
+            value={summary?.lateCount ?? 0}
+            unit="명"
+            icon={<Clock />}
+            variant="yellow"
+          />
+          <CountCard
+            label="결석인원"
+            value={summary?.absentCount ?? 0}
+            unit="명"
+            icon={<UserX />}
+            variant="red"
+          />
+          <CountCard
+            label="휴가승인대기"
+            value={summary?.pendingLeaveCount ?? 0}
+            unit="명"
+            icon={<ScrollText />}
+            variant="orange"
+          />
+        </section>
+        <div className={S.topGrid}>
+          <section className={S.chartSection}>
+            <div className={S.chartPlaceholder}>출결 현황 차트 영역</div>
+          </section>
+
+          <section className={S.noticeSection}>
+            <SystemNoticeList />
+          </section>
+        </div>
+
+        <section className={S.recentLeave}>
+          <h3>휴가 관리 테이블</h3>
+          <Table
+            columns={vacationColumns}
+            data={vacationData}
+            totalCount={248}
+            currentPage={1}
+            pageSize={12}
+            countLabel="명"
+          />
+
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={setCurrentPage}
+          />
+        </section>
+      </div>
+    </AdminLayout>
+  )
+}

--- a/frontend/src/pages/admin/dashboard/components/AttendanceStatusChart.tsx
+++ b/frontend/src/pages/admin/dashboard/components/AttendanceStatusChart.tsx
@@ -1,0 +1,3 @@
+export default function AttendanceStatusChart() {
+  return <div>출결 현황 그래프</div>
+}

--- a/frontend/src/pages/admin/dashboard/components/NoticeList.tsx
+++ b/frontend/src/pages/admin/dashboard/components/NoticeList.tsx
@@ -1,0 +1,27 @@
+import S from '@/pages/admin/dashboard/styles/dashboard.module.css'
+
+const notices = [
+  { id: 1, title: '4월 훈련평가 일정', date: '2026.04.20' },
+  { id: 2, title: '공결 신청 시 증빙서류 제출 항목', date: '2026.04.11' },
+  { id: 3, title: '공결 신청 시 증빙서류 제출 항목', date: '2026.04.11' },
+  { id: 4, title: '공결 신청 시 증빙서류 제출 항목', date: '2026.04.11' },
+  { id: 4, title: '공결 신청 시 증빙서류 제출 항목', date: '2026.04.11' },
+  { id: 4, title: '공결 신청 시 증빙서류 제출 항목', date: '2026.04.11' },
+]
+
+export default function NoticeList() {
+  return (
+    <div className={S.container}>
+      <h2 className={S.title}>시스템 공지사항</h2>
+
+      <ul className={S.list}>
+        {notices.slice(0, 4).map((notice, index) => (
+          <li key={notice.id} className={`${S.item} ${index === 0 ? S.highlight : ''}`}>
+            <p className={S.noticeTitle}>{notice.title}</p>
+            <span className={S.date}>{notice.date}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/frontend/src/pages/admin/dashboard/styles/dashboard.module.css
+++ b/frontend/src/pages/admin/dashboard/styles/dashboard.module.css
@@ -1,0 +1,176 @@
+.container {
+  display: flex;
+  flex-direction: column;
+
+  block-size: 100%;
+  padding: 24px 28px;
+
+  text-align: left;
+
+  background: #ffffff;
+  border: 2px solid #dddddd;
+  border-radius: 18px;
+}
+
+.title {
+  margin: 0 0 16px;
+
+  font-weight: 800;
+  font-size: 22px;
+  color: #111111;
+  text-align: left;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+
+  margin: 0;
+  padding: 0;
+
+  list-style: none;
+}
+
+.item {
+  padding: 18px 22px;
+
+  text-align: left;
+
+  background: #f8f8f8;
+  border: 2px solid #dddddd;
+  border-radius: 10px;
+}
+
+.highlight {
+  background: #fff3eb;
+  border-color: #ff5a00;
+}
+
+.noticeTitle {
+  margin: 0 0 6px;
+
+  font-weight: 700;
+  font-size: 16px;
+  color: #666666;
+  text-align: left;
+}
+
+.highlight .noticeTitle {
+  color: #ff5a00;
+}
+
+.date {
+  display: block;
+
+  font-size: 14px;
+  color: #666666;
+  text-align: left;
+}
+
+.chartSection {
+  inline-size: 100%;
+}
+
+.chartPlaceholder {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  min-block-size: 280px;
+  padding: 24px;
+
+  color: #999999;
+
+  background: #ffffff;
+  border: 2px dashed #dddddd;
+  border-radius: 18px;
+}
+
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+
+  inline-size: 100%;
+}
+
+.topGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  align-items: stretch;
+  gap: 24px;
+
+  inline-size: 100%;
+}
+
+.chartSection,
+.noticeSection {
+  min-inline-size: 0;
+}
+
+.chartPlaceholder {
+  block-size: 100%;
+  min-block-size: 360px;
+}
+
+.leaveSection {
+  inline-size: 100%;
+}
+
+.cardSection {
+  display: flex;
+  justify-content: flex-start;
+  gap: 16px;
+
+  inline-size: 100%;
+}
+
+.cardSection > * {
+  flex: 0 0 220px;
+}
+
+/* table */
+.tit,
+.name {
+  color: var(--default-black);
+}
+
+.circle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  margin: 0 10px 0 0;
+  border-radius: 50%;
+  background-color: var(--default-orange);
+  color: #fff;
+}
+
+.statusBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 102px;
+  height: 30px;
+  padding: 0 5px;
+  border-radius: 20px;
+  font-weight: var(--Md);
+  font-size: var(--sub-title);
+  line-height: var(--big-title);
+}
+
+.vacationSick,
+.vacationOfficial,
+.vacationPersonal {
+  color: #ff6b00;
+  border: 1px solid #ff6b00;
+  background-color: #fff4ed;
+}
+
+.actionBox {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}


### PR DESCRIPTION
# 📌 개요

- 관리자용 대시보드 페이지 구현

## 💻 작업 사항

- 관리자 대시보드 레이아웃 구성
- 공통 컴포넌트 CountCard 적용
- 공통 컴포넌트 Table 적용 (휴가 관리 테이블) > 휴가 신청 내역으로 변경 가능
- 공통 컴포넌트 Pagination 연결 (페이지 상태 관리) > 테이블 안에 적용 불가 
- 출결 현황 차트 영역 placeholder 구성

## 📸 스크린샷 (선택)

<img width="1580" height="765" alt="image" src="https://github.com/user-attachments/assets/b4a90f5f-aa64-443e-844f-ffd587435040" />
  
## 📎 참고 사항 (선택)

<img width="1552" height="673" alt="image" src="https://github.com/user-attachments/assets/9e519b5b-4cb5-49ae-982e-22a6f3ae28fa" />

- 휴가 관리 테이블 하단에 페이지네이션 위치. 테이블 내에 적용할 경우 공통 컴포넌트 (테이블) 수정 필요..

## 💡 관련 Issue

Closes #56 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #)
- [x] 불필요한 console.log를 제거했습니다.
- [ ] 사용하지 않는 코드/파일을 정리했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
