### PR TITLE
feat: 관리자 대시보드 출결 현황 차트(막대 그래프) 구현(CSS)

### DIFF
--- a/frontend/src/pages/admin/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/admin/dashboard/DashboardPage.tsx
@@ -7,7 +7,7 @@ import {
   getAdminDashboardSummary,
   type AdminDashboardData,
 } from '@/pages/admin/dashboard/api/dashboardApi'
-// import AttendanceStatusChart from './components/AttendanceStatusChart'
+import AttendanceStatusChart from '@/pages/admin/dashboard/components/AttendanceStatusChart'
 import SystemNoticeList from './components/NoticeList'
 import Table, { type TableColumn } from '@/components/common/table'
 import { Button } from '@/components'
@@ -172,7 +172,9 @@ export default function AdminDashboardPage() {
         </section>
         <div className={S.topGrid}>
           <section className={S.chartSection}>
-            <div className={S.chartPlaceholder}>출결 현황 차트 영역</div>
+            <div className={S.container}>
+              <AttendanceStatusChart />
+            </div>
           </section>
 
           <section className={S.noticeSection}>

--- a/frontend/src/pages/admin/dashboard/components/AttendanceStatusChart.tsx
+++ b/frontend/src/pages/admin/dashboard/components/AttendanceStatusChart.tsx
@@ -1,3 +1,79 @@
+import S from '@/pages/admin/dashboard/styles/dashboard.module.css'
+
 export default function AttendanceStatusChart() {
-  return <div>출결 현황 그래프</div>
+  const attendanceChartData = [
+    {
+      course: '웹 개발 기초 과정',
+      total: 50,
+      present: 42,
+      late: 6,
+      absent: 2,
+    },
+    {
+      course: 'UI/UX 디자인 심화',
+      total: 50,
+      present: 42,
+      late: 6,
+      absent: 2,
+    },
+    {
+      course: '데이터 분석 입문',
+      total: 50,
+      present: 42,
+      late: 6,
+      absent: 2,
+    },
+    {
+      course: '프론트엔드 프레임워크',
+      total: 50,
+      present: 50,
+      late: 0,
+      absent: 0,
+    },
+    {
+      course: '모바일 앱 개발',
+      total: 50,
+      present: 42,
+      late: 6,
+      absent: 2,
+    },
+  ]
+
+  return (
+    <section className={S.attendanceChartSection}>
+      <h3 className={S.sectionTitle}>오늘의 전체 출결 현황</h3>
+
+      <div className={S.chartList}>
+        {attendanceChartData.map((item) => (
+          <div key={item.course} className={S.chartItem}>
+            <div className={S.chartHeader}>
+              <strong className={S.courseName}>{item.course}</strong>
+              <span className={S.totalCount}>{item.total}명</span>
+            </div>
+
+            <div className={S.barTrack}>
+              <div
+                className={S.presentBar}
+                style={{ inlineSize: `${(item.present / item.total) * 100}%` }}
+              />
+              <div
+                className={S.lateBar}
+                style={{ inlineSize: `${(item.late / item.total) * 100}%` }}
+              />
+              <div
+                className={S.absentBar}
+                style={{ inlineSize: `${(item.absent / item.total) * 100}%` }}
+              />
+            </div>
+
+            <div className={S.legend}>
+              <span className={S.presentDot}>출석완료 {item.present}명</span>
+              <span className={S.lateDot}>지각인원 {item.late}명</span>
+              <span className={S.absentDot}>결석인원 {item.absent}명</span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
 }

--- a/frontend/src/pages/admin/dashboard/styles/dashboard.module.css
+++ b/frontend/src/pages/admin/dashboard/styles/dashboard.module.css
@@ -68,10 +68,6 @@
   text-align: left;
 }
 
-.chartSection {
-  inline-size: 100%;
-}
-
 .chartPlaceholder {
   display: flex;
   justify-content: center;
@@ -191,4 +187,124 @@
 .paginationBox {
   display: flex;
   justify-content: center;
+}
+
+.chartSection {
+  inline-size: 100%;
+}
+
+.chartSection .container {
+  inline-size: 100%;
+}
+
+.chartItem {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.barTrack {
+  display: flex;
+  overflow: hidden;
+
+  inline-size: 100%;
+  block-size: 14px;
+
+  background: #f1f3f5;
+  border-radius: 999px;
+}
+
+.attendanceChartSection {
+  display: flex;
+  flex-direction: column;
+
+  inline-size: 100%;
+}
+
+.sectionTitle {
+  margin: 0 0 18px;
+
+  font-weight: 800;
+  font-size: 22px;
+  color: #111111;
+  text-align: left;
+}
+
+.chartList {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.chartHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.courseName {
+  font-weight: 700;
+  font-size: 16px;
+  color: #333333;
+}
+
+.totalCount {
+  font-size: 14px;
+  color: #666666;
+}
+
+.presentBar,
+.lateBar,
+.absentBar {
+  block-size: 100%;
+}
+
+.presentBar {
+  background: #00b050;
+}
+
+.lateBar {
+  background: #ffc000;
+}
+
+.absentBar {
+  background: #e60000;
+}
+
+.legend {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+
+  margin-top: 2px;
+
+  font-size: 11px;
+  color: #777777;
+}
+
+.legend span {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.legend span::before {
+  content: '';
+
+  inline-size: 7px;
+  block-size: 7px;
+
+  border-radius: 50%;
+}
+
+.presentDot::before {
+  background: #00b050;
+}
+
+.lateDot::before {
+  background: #ffc000;
+}
+
+.absentDot::before {
+  background: #e60000;
 }


### PR DESCRIPTION
## 📌 개요

- 관리자 대시보드 내 출결 현황 차트 UI를 추가(CSS + 더미 데이터)

## 🔁 변경 사항 (재PR 시 작성)

- CSS 기반으로 간단히 구현
- 차후 API 연동 및 차트 라이브러리 적용

## 📸 스크린샷 (선택)

<img width="853" height="818" alt="image" src="https://github.com/user-attachments/assets/68b295c9-4329-4a75-a5a3-1811618e14c0" />

  
## 💡 관련 Issue

Closes #56 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #)
- [x] 불필요한 console.log를 제거했습니다.
- [ ] 사용하지 않는 코드/파일을 정리했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
 