### PR TITLE
Feat/req04/dashboard header

### DIFF
--- a/frontend/src/components/common/header/header.tsx
+++ b/frontend/src/components/common/header/header.tsx
@@ -1,72 +1,82 @@
-import { useLocation } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import S from './header.module.css'
 
-// 타이틀 리스트
-const Title_label : Record<string, Record<string, string>> ={
-  student: {
-    dashboard: '대시보드',
-    leave: '휴가신청',
-    notice: '공지사항',
-    settings: '환경설정', // 수정 2: setting -> settings
-  },
-  admin:{
-    dashboard: '대시보드',
-    notice: '공지사항',
-    leave: '휴가 승인',
-    lecture: '강의 관리',
-    student: '학생 관리',
-    attendance: '출결 관리',
-    settings: '설정',
-  },
-};
+const Title_label: Record<string, Record<string, string>> = {
+    student: {
+        dashboard: '대시보드',
+        leave: '휴가신청',
+        notice: '공지사항',
+        settings: '환경설정',
+    },
+    admin: {
+        dashboard: '대시보드',
+        notice: '공지사항',
+        leave: '휴가 승인',
+        lecture: '강의 관리',
+        student: '학생 관리',
+        attendance: '출결 관리',
+        settings: '설정',
+    },
+}
 
 function Header() {
-  const location = useLocation()
-  const pathSegment = location.pathname.split('/');
-  
-  const menuRole = pathSegment[1] || 'student';
-  const category = pathSegment[2] || 'dashboard';
+    const location = useLocation()
+    const navigate = useNavigate()
 
-  // 수정 1: [menuRole] 뒤에 물음표(?) 추가하여 에러 방지
-  const pageTitle = Title_label[menuRole]?.[category] || '대시보드';
-  
-  const subTitle = menuRole === 'admin'
-  ? '관리자님 환영합니다.'
-  : '오늘도 멋사와 함께 열공하세요!';
+    const pathSegment = location.pathname.split('/')
+    const menuRole = pathSegment[1] || 'student'
+    const category = pathSegment[2] || 'dashboard'
 
-  const loginUser = {
-    name: '백희연',
-    accountEng: 'heeyeon_baek',
-  }
+    const pageTitle = Title_label[menuRole]?.[category] || '대시보드'
 
-  const userInitials = menuRole === 'admin' ? '관' 
-  : (loginUser.name ? loginUser.name[0] : '학');
-  
-  return (
-    <header className={S.header}>
-      <div className={S.title}>
-        <h1 className={S.menu_name}>{pageTitle}</h1>
-        <p className={S.sub_title}>{subTitle}</p>
-      </div>
-      <div className={S.user_profile}>
-        <div className={S.user_icons}>
-          <span className={S.user_first_name}>
-            {userInitials}
-          </span>
-          <div className={S.user_status}>
-            {/* 수정 3: 관리자일 때 이름/계정도 '관리자'에 맞게 노출 */}
-            <p className={S.account_name}>
-              {menuRole === 'admin' ? '관리자' : loginUser.name}
-            </p>
-            <p className={S.account_eng}>
-              {menuRole === 'admin' ? 'LikeLion_admin' : loginUser.accountEng}
-            </p>
-          </div>
-        </div>
-        <button className={S.logout_button}>로그아웃</button>
-      </div>
-    </header>
-  )
+    const subTitle = menuRole === 'admin'
+        ? '관리자님 환영합니다.'
+        : '오늘도 멋사와 함께 열공하세요!'
+
+    // localStorage에서 유저 정보 읽기
+    const userName = localStorage.getItem('userName') || '이름 없음'
+    
+    const userInitials = menuRole === 'admin' ? '관'
+        : (userName ? userName[0] : '학')
+
+    // 로그아웃
+    const handleLogout = () => {
+        localStorage.removeItem('accessToken')
+        localStorage.removeItem('userName')
+        localStorage.removeItem('studentId')
+        localStorage.removeItem('role')
+        navigate('/login')
+    }
+
+    return (
+        <header className={S.header}>
+            <div className={S.title}>
+                <h1 className={S.menu_name}>{pageTitle}</h1>
+                <p className={S.sub_title}>{subTitle}</p>
+            </div>
+            <div className={S.user_profile}>
+                <div className={S.user_icons}>
+                    <span className={S.user_first_name}>
+                        {userInitials}
+                    </span>
+                    <div className={S.user_status}>
+                        <p className={S.account_name}>
+                            {menuRole === 'admin' ? '관리자' : userName}
+                        </p>
+                        <p className={S.account_eng}>
+                             {menuRole === 'admin' ? 'LikeLion_admin' : 'likelion-student'}
+                        </p>
+                    </div>
+                </div>
+                <button
+                    className={S.logout_button}
+                    onClick={handleLogout}
+                >
+                    로그아웃
+                </button>
+            </div>
+        </header>
+    )
 }
 
 export default Header

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -4,3 +4,5 @@ export {default as Button} from './common/button/ui/button'
 
 export {default as SearchBar} from './common/search/search'
 export {default as Sidebar} from './common/sidebar/Sidebar'
+
+export {default as Pagination} from './common/pagination/Pagination'


### PR DESCRIPTION
<!--
  PR 작성 가이드
  - 리뷰어를 존중하는 표현을 사용해주세요.
  - 변경 의도와 주요 내용을 명확하게 작성해주세요.
 -->

## 📌 개요

- Header 페이지 로그인 시 로그인 정보 연결 

## 💻 작업 사항

1. Header 컴포넌트 기능 구현
- localStorage에서 유저 정보(이름, 학번) 읽어서 Header에 표시
- 로그아웃 버튼 클릭 시 localStorage 초기화 후 로그인 페이지(/) 이동
- 관리자/학생 역할에 따른 표시 분기 처리

2. 변경 사항
- `loginUser` 하드코딩 제거
- `localStorage.getItem('userName')` 으로 유저 이름 동적 표시
- 계정 표기: 학생 `likelion-student` / 관리자 `LikeLion_admin` 고정
- 로그아웃 핸들러 추가 (`handleLogout`)
- `useNavigate` import 추가

3. 추후 작업 예정
- 로그인 API 연동 후 실제 토큰/유저 정보 저장 연동
- axios 인터셉터 추가 (별도 PR)
- loginApi.ts 작성 (별도 PR)

4. 테스트
- localStorage에 임시 데이터 삽입 후 Header 유저 정보 표시 확인
- 로그아웃 버튼 클릭 시 `/` 로 이동 확인
- 관리자/학생 경로별 분기 표시 확인

## 🔁 변경 사항 (재PR 시 작성)

- 수정 또는 보완한 내용을 작성해주세요.

## 📸 스크린샷 (선택)

<img width="1007" height="611" alt="image" src="https://github.com/user-attachments/assets/deb3755d-4580-4605-b5dd-2b4de49671b8" />
  
## 📎 참고 사항 (선택)

- 작업한 내용의 참고할 사항을 남겨주세요.
  
## 💡 관련 Issue

Closes #68 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #)
- [x] 불필요한 console.log를 제거했습니다.
- [x] 사용하지 않는 코드/파일을 정리했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
