### PR TITLE
[feat] 비밀번호 찾기, 비밀번호 변경 API 연결

### DIFF
--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -6,7 +6,6 @@ import ResetPassword from './components/ResetPassword'
 import './styles/login.css'
 
 export default function LoginPage() {
-  // 현재 어떤 화면(학생로그인, 관리자로그인, 비번찾기 등)을 보여줄지 결정하는 상태
   const { view, set_view } = useAuthView()
 
   return (

--- a/frontend/src/pages/auth/api/loginApi.ts
+++ b/frontend/src/pages/auth/api/loginApi.ts
@@ -23,7 +23,6 @@ export const post_login_api = async (studentId: string, password: string) => {
   const result = await response.json()
 
   if (!response.ok) {
-    // 통신은 성공했으나, 백엔드에서 에러(비밀번호 틀림 등)를 보낸 경우
     throw new Error(result.message || '로그인 실패')
   }
 

--- a/frontend/src/pages/auth/components/AdminLoginForm.tsx
+++ b/frontend/src/pages/auth/components/AdminLoginForm.tsx
@@ -9,7 +9,6 @@ function AdminLoginForm({ onChangeView }: AdminLoginFormProps) {
   const [admin_id, set_admin_id] = useState('')
   const [password, set_password] = useState('')
 
-  // 학생 로그인과 동일한 훅을 사용하되, 결과 처리에서 역할을 구분합니다.
   const { login_user, is_loading, error_message } = useLogin()
 
   const handle_admin_login = async (event: React.SubmitEvent<HTMLFormElement>) => {

--- a/frontend/src/pages/auth/components/FindPassword.tsx
+++ b/frontend/src/pages/auth/components/FindPassword.tsx
@@ -23,6 +23,8 @@ function FindPassword({ onChangeView }: FindPasswordProps) {
 
       const result = await response.json()
 
+      sessionStorage.setItem('reset_student_id', result.data.studentId)
+
       if (response.ok) {
         alert('본인 인증이 완료되었습니다. 새 비밀번호를 설정해 주세요.')
         onChangeView('RESET_PASSWORD')

--- a/frontend/src/pages/auth/components/LoginForm.tsx
+++ b/frontend/src/pages/auth/components/LoginForm.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useLogin } from '../hooks/useLogin'
 
 interface LoginFormProps {
@@ -9,6 +10,7 @@ function LoginForm({ onChangeView }: LoginFormProps) {
   const [studentId, set_studentId] = useState('')
   const [password, set_password] = useState('')
 
+  const navigate = useNavigate()
   const { login_user, is_loading, error_message } = useLogin()
 
   const handle_login = async (event: React.SubmitEvent<HTMLFormElement>) => {
@@ -19,6 +21,12 @@ function LoginForm({ onChangeView }: LoginFormProps) {
     if (result.success) {
       if (result.role === 'ADMIN') {
         alert('관리자 계정입니다. 관리자 로그인 탭을 이용해주세요.')
+        return
+      }
+
+      if (studentId === password) {
+        alert('초기 비밀번호를 사용 중입니다. 안전을 위해 비밀번호를 먼저 변경해 주세요.')
+        navigate('/student/settings')
         return
       }
 

--- a/frontend/src/pages/auth/components/ResetPassword.tsx
+++ b/frontend/src/pages/auth/components/ResetPassword.tsx
@@ -1,52 +1,90 @@
 import { useState } from 'react'
 
 interface ResetPasswordProps {
-  onChangeView: (view: 'LOGIN' | 'FIND_PASSWORD' | 'RESET_PASSWORD') => void
+  onChangeView: (view: 'LOGIN' | 'ADMIN_LOGIN' | 'FIND_PASSWORD' | 'RESET_PASSWORD') => void
 }
 
 function ResetPassword({ onChangeView }: ResetPasswordProps) {
   const [new_password, set_new_password] = useState('')
   const [confirm_password, set_confirm_password] = useState('')
 
-  const handle_reset = async (event: React.SubmitEvent<HTMLFormElement>) => {
+  const handle_reset = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
 
-    // 프론트엔드 1차 유효성 검사
     if (new_password !== confirm_password) {
       alert('비밀번호가 일치하지 않습니다. 다시 확인해 주세요.')
       return
     }
 
-    // TODO: 한결님의 PATCH /api/student/settings/password API 연동
-    // 성공 시 onChangeView('LOGIN') 호출
+    try {
+      const target_student_id = sessionStorage.getItem('reset_student_id')
+
+      if (!target_student_id) {
+        alert('인증 정보가 만료되었습니다. 다시 본인 인증을 진행해 주세요.')
+        onChangeView('FIND_PASSWORD')
+        return
+      }
+
+      const API_URL = `${import.meta.env.VITE_API_BASE_URL}/api/auth/reset-password`
+
+      const response = await fetch(API_URL, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          studentId: target_student_id,
+          newPassword: new_password,
+        }),
+      })
+
+      const result = await response.json()
+
+      if (response.ok) {
+        alert('비밀번호가 성공적으로 변경되었습니다! 새 비밀번호로 로그인해 주세요.')
+
+        sessionStorage.removeItem('reset_student_id')
+
+        onChangeView('LOGIN')
+      } else {
+        alert(result.message || '비밀번호 변경에 실패했습니다.')
+      }
+    } catch (error) {
+      console.error('비밀번호 재설정 에러:', error)
+      alert('서버와 연결할 수 없습니다.')
+    }
   }
 
   return (
-    <div className="auth_content">
+    <section className="auth_content">
       <form className="login_form" onSubmit={handle_reset}>
-        <div className="input_group">
-          <label className="input_label">새 비밀번호</label>
-          <input
-            type="password"
-            placeholder="비밀번호 8자 이상 영문+숫자 조합"
-            className="input_field"
-            value={new_password}
-            onChange={(event) => set_new_password(event.target.value)}
-            required
-          />
-        </div>
+        <fieldset className="input_group">
+          <label className="input_label">
+            <span>새 비밀번호</span>
+            <input
+              type="password"
+              placeholder="비밀번호 8자 이상 영문+숫자 조합"
+              className="input_field"
+              value={new_password}
+              onChange={(event) => set_new_password(event.target.value)}
+              required
+            />
+          </label>
+        </fieldset>
 
-        <div className="input_group">
-          <label className="input_label">새 비밀번호 확인</label>
-          <input
-            type="password"
-            placeholder="새 비밀번호를 입력하세요"
-            className="input_field"
-            value={confirm_password}
-            onChange={(event) => set_confirm_password(event.target.value)}
-            required
-          />
-        </div>
+        <fieldset className="input_group">
+          <label className="input_label">
+            <span>새 비밀번호 확인</span>
+            <input
+              type="password"
+              placeholder="새 비밀번호를 다시 입력하세요"
+              className="input_field"
+              value={confirm_password}
+              onChange={(event) => set_confirm_password(event.target.value)}
+              required
+            />
+          </label>
+        </fieldset>
 
         <button type="submit" className="login_submit_button">
           비밀번호 변경 완료
@@ -58,7 +96,7 @@ function ResetPassword({ onChangeView }: ResetPasswordProps) {
           취소하고 돌아가기
         </button>
       </div>
-    </div>
+    </section>
   )
 }
 

--- a/frontend/src/pages/auth/components/ResetPassword.tsx
+++ b/frontend/src/pages/auth/components/ResetPassword.tsx
@@ -11,6 +11,12 @@ function ResetPassword({ onChangeView }: ResetPasswordProps) {
   const handle_reset = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
 
+    const password_regex = /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,}$/
+    if (!password_regex.test(new_password)) {
+      alert('비밀번호는 8자 이상, 영문과 숫자를 혼합해야 합니다.')
+      return
+    }
+
     if (new_password !== confirm_password) {
       alert('비밀번호가 일치하지 않습니다. 다시 확인해 주세요.')
       return


### PR DESCRIPTION
## 📌 개요

- 비밀번호 찾기, 비밀번호 변경 API 연결

## 💻 작업 사항

- 이름과 전화번호로 유효성 검사
- 유효 값을 가지고 비밀번호 변경 view로 이동
- 새 비밀번호, 새 비밀번호 확인 (영어 숫자 혼합 8글자 이상)
- 비밀번호 확인 시 처음 로그인 view로 이동하여 변경된 비밀번호로 로그인
- 학번과 비밀번호가 같을 시 학생 설정 창으로 이동하는 기능 추가

## 🔁 변경 사항 (재PR 시 작성)

- 수정 또는 보완한 내용을 작성해주세요.

## 📸 스크린샷 (선택)

- 작업한 내용을 남겨주세요.
  
## 📎 참고 사항 (선택)

- 작업한 내용의 참고할 사항을 남겨주세요.
  
## 💡 관련 Issue

Closes #92 

## ✅ 체크리스트

- [✅] 관련 이슈를 연결했습니다. (Closes #)
- [✅] 불필요한 console.log를 제거했습니다.
- [✅] 사용하지 않는 코드/파일을 정리했습니다.
- [✅] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [✅] 기능이 정상 동작하는지 확인했습니다.
