### PR TITLE
feat: 공지사항 목록 API 연동 및 페이지 이동 기능 추가

### DIFF
--- a/frontend/src/pages/admin/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/admin/dashboard/DashboardPage.tsx
@@ -6,8 +6,10 @@ import CountCard from '@/components/common/countCard/CountCard'
 import {
   getAdminDashboardSummary,
   getAttendanceStatusByClass,
+  getNoticeList,
   type AttendanceItem,
   type AdminDashboardData,
+  type NoticeItem,
 } from '@/pages/admin/dashboard/api/dashboardApi'
 import AttendanceStatusChart from '@/pages/admin/dashboard/components/AttendanceStatusChart'
 import SystemNoticeList from './components/NoticeList'
@@ -66,6 +68,21 @@ export default function AdminDashboardPage() {
   const [summary, setSummary] = useState<AdminDashboardData | null>(null)
   const [attendanceData, setAttendanceData] = useState<AttendanceItem[]>([])
   const [currentPage, setCurrentPage] = useState(1)
+
+  const [noticeData, setNoticeData] = useState<NoticeItem[]>([])
+
+  useEffect(() => {
+    const fetchNoticeList = async () => {
+      try {
+        const data = await getNoticeList()
+        setNoticeData(data)
+      } catch (error) {
+        console.error(error)
+      }
+    }
+
+    fetchNoticeList()
+  }, [])
 
   useEffect(() => {
     const fetchSummary = async () => {
@@ -194,7 +211,9 @@ export default function AdminDashboardPage() {
           </section>
 
           <section className={S.noticeSection}>
-            <SystemNoticeList />
+            <div className={S.container}>
+              <SystemNoticeList data={noticeData} />
+            </div>
           </section>
         </div>
 

--- a/frontend/src/pages/admin/dashboard/api/dashboardApi.ts
+++ b/frontend/src/pages/admin/dashboard/api/dashboardApi.ts
@@ -36,3 +36,18 @@ export async function getAttendanceStatusByClass() {
 
   return response.data.data
 }
+
+export interface NoticeItem {
+  displayNo: number
+  noticeId: number
+  title: string
+  createdDate: string
+  isOpen: boolean
+  openStatusName: string
+}
+
+export async function getNoticeList() {
+  const response = await api.get('/api/admin/notices')
+
+  return response.data.data.items
+}

--- a/frontend/src/pages/admin/dashboard/components/NoticeList.tsx
+++ b/frontend/src/pages/admin/dashboard/components/NoticeList.tsx
@@ -1,27 +1,29 @@
 import S from '@/pages/admin/dashboard/styles/dashboard.module.css'
+import type { NoticeItem } from '@/pages/admin/dashboard/api/dashboardApi'
+import { useNavigate } from 'react-router-dom'
 
-const notices = [
-  { id: 1, title: '4월 훈련평가 일정', date: '2026.04.20' },
-  { id: 2, title: '공결 신청 시 증빙서류 제출 항목', date: '2026.04.11' },
-  { id: 3, title: '공결 신청 시 증빙서류 제출 항목', date: '2026.04.11' },
-  { id: 4, title: '공결 신청 시 증빙서류 제출 항목', date: '2026.04.11' },
-  { id: 4, title: '공결 신청 시 증빙서류 제출 항목', date: '2026.04.11' },
-  { id: 4, title: '공결 신청 시 증빙서류 제출 항목', date: '2026.04.11' },
-]
+interface Props {
+  data: NoticeItem[]
+}
 
-export default function NoticeList() {
+export default function NoticeList({ data }: Props) {
+  const navigate = useNavigate()
   return (
-    <div className={S.container}>
-      <h2 className={S.title}>시스템 공지사항</h2>
+    <>
+      <h3 className={S.title}>시스템 공지사항</h3>
 
       <ul className={S.list}>
-        {notices.slice(0, 4).map((notice, index) => (
-          <li key={notice.id} className={`${S.item} ${index === 0 ? S.highlight : ''}`}>
-            <p className={S.noticeTitle}>{notice.title}</p>
-            <span className={S.date}>{notice.date}</span>
+        {data.slice(0, 5).map((item, index) => (
+          <li
+            key={item.noticeId}
+            className={`${S.item} ${index === 0 ? S.highlight : ''}`}
+            onClick={() => navigate('/admin/notice')}
+          >
+            <strong className={S.noticeTitle}>{item.title}</strong>
+            <span className={S.noticeDate}>{item.createdDate}</span>
           </li>
         ))}
       </ul>
-    </div>
+    </>
   )
 }

--- a/frontend/src/pages/admin/dashboard/styles/dashboard.module.css
+++ b/frontend/src/pages/admin/dashboard/styles/dashboard.module.css
@@ -3,9 +3,7 @@
   flex-direction: column;
 
   block-size: 100%;
-  padding: 24px 28px;
-
-  text-align: left;
+  padding: 56px 36px 32px;
 
   background: #ffffff;
   border: 2px solid #dddddd;
@@ -13,18 +11,19 @@
 }
 
 .title {
-  margin: 0 0 16px;
+  margin: 0 0 28px;
 
-  font-weight: 800;
-  font-size: 22px;
+  font-weight: 700;
+  font-size: 20px;
   color: #111111;
+
   text-align: left;
 }
 
 .list {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 8px;
 
   margin: 0;
   padding: 0;
@@ -33,13 +32,27 @@
 }
 
 .item {
-  padding: 18px 22px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 
+  align-items: flex-start;
   text-align: left;
 
-  background: #f8f8f8;
+  gap: 4px;
+
+  min-block-size: 52px;
+  padding: 10px 14px;
+
+  background: #ffffff;
   border: 2px solid #dddddd;
-  border-radius: 10px;
+  border-radius: 8px;
+
+  cursor: pointer;
+}
+
+.item:hover {
+  background: #f2f2f2;
 }
 
 .highlight {
@@ -48,16 +61,18 @@
 }
 
 .noticeTitle {
-  margin: 0 0 6px;
-
   font-weight: 700;
   font-size: 16px;
-  color: #666666;
-  text-align: left;
+  color: #333333;
 }
 
 .highlight .noticeTitle {
   color: #ff5a00;
+}
+
+.noticeDate {
+  font-size: 14px;
+  color: #777777;
 }
 
 .date {
@@ -194,7 +209,7 @@
 }
 
 .chartSection .container {
-  inline-size: 100%;
+  padding-top: 24px;
 }
 
 .chartItem {
@@ -219,6 +234,7 @@
   flex-direction: column;
 
   inline-size: 100%;
+  padding-top: 0;
 }
 
 .sectionTitle {
@@ -310,4 +326,9 @@
 
 .absentDot::before {
   background: #e60000;
+}
+
+.highlight {
+  background: #fff3eb;
+  border: 2px solid #ffb48a;
 }


### PR DESCRIPTION
## 📌 개요

- 공지사항 목록 API 연동

## 💻 작업 사항

- 공지사항 API 데이터 연동
- 최대 5개 공지 표시
- 최신 공지 강조 스타일 적용
- 공지 클릭 시 공지사항 페이지 이동 기능 구현
- 
## 📸 스크린샷 (선택)

<img width="842" height="773" alt="image" src="https://github.com/user-attachments/assets/77dc9a29-243e-4798-8af7-02d63e49bb84" />

## 📎 참고 사항 (선택)

## 💡 관련 Issue

Closes #

## ✅ 체크리스트

- [ ] 관련 이슈를 연결했습니다. (Closes #)
- [x] 불필요한 console.log를 제거했습니다.
- [ ] 사용하지 않는 코드/파일을 정리했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
