### PR TITLE
fix: JWT 기반 학생 대시보드 출결 현황 및  캘린더 API 연동

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,8 @@
     "": {
       "dependencies": {
         "axios": "^1.15.2",
+        "jwt-decode": "^4.0.0",
+        "react-loading-skeleton": "^3.5.0",
       },
     },
   },
@@ -47,6 +49,8 @@
 
     "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
+    "jwt-decode": ["jwt-decode@4.0.0", "", {}, "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
     "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
@@ -54,5 +58,9 @@
     "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
+
+    "react": ["react@19.2.6", "", {}, "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q=="],
+
+    "react-loading-skeleton": ["react-loading-skeleton@3.5.0", "", { "peerDependencies": { "react": ">=16.8.0" } }, "sha512-gxxSyLbrEAdXTKgfbpBEFZCO/P153DnqSCQau2+o6lNy1jgMRr2MmRmOzMmyrwSaSYLRB8g7b0waYPmUjz7IhQ=="],
   }
 }

--- a/frontend/src/pages/student/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/student/dashboard/DashboardPage.tsx
@@ -24,6 +24,17 @@ interface NoticeListProps {
   onNoticeClick: (noticeId: number) => void
 }
 
+interface LeaveItem {
+  leaveRequestId: number
+  studentId: string
+  leaveTypeCode: string
+  leaveTypeName: string
+  startDate: string
+  endDate: string
+  approvalStatusCode: string
+  approvalStatusName: string
+}
+
 function DashboardPage() {
   const [now, setNow] = useState(new Date())
 
@@ -80,30 +91,24 @@ function DashboardPage() {
   useEffect(() => {
     const fetchAttendanceItems = async () => {
       try {
-        const response = await api.get('/api/admin/attendances', {
+        const response = await api.get('/api/student/attendance-calendar', {
           params: {
-            size: 40,
+            year: 2026,
+            month: 4,
           },
         })
 
-        console.log('출결 목록 응답:', response.data)
+        console.log('출결 캘린더 응답:', response.data)
 
-        console.log(
-          '전체 studentId 목록:',
-          response.data.data.items.map((item: { studentId: string }) => item.studentId),
-        )
+        if (!response.data.success) {
+          setAttendanceItems([])
+          return
+        }
 
-        const studentId = localStorage.getItem('studentId')
-
-        const myAttendanceItems = response.data.data.items.filter(
-          (item: { studentId: string }) => item.studentId === studentId,
-        )
-
-        console.log('내 출결 목록:', myAttendanceItems)
-
-        setAttendanceItems(myAttendanceItems)
+        setAttendanceItems(response.data.data.items ?? [])
       } catch (error) {
-        console.error('출결 목록 조회 실패:', error)
+        console.error('출결 캘린더 조회 실패:', error)
+        setAttendanceItems([])
       }
     }
 
@@ -226,19 +231,69 @@ function DashboardPage() {
 }
 
 function LeaveStatus() {
+  const navigate = useNavigate()
+
+  const [leaveList, setLeaveList] = useState<LeaveItem[]>([])
+
+  useEffect(() => {
+    const fetchLeaveList = async () => {
+      try {
+        const response = await api.get('/api/student/leave-requests', {
+          params: {
+            page: 1,
+            size: 10,
+          },
+        })
+
+        console.log('휴가 목록 응답 전체:', response.data)
+        console.log('휴가 items:', response.data.data?.items)
+
+        console.log('휴가 목록 응답:', response.data)
+
+        if (!response.data.success) {
+          setLeaveList([])
+          return
+        }
+
+        setLeaveList(response.data.data.items ?? [])
+      } catch (error) {
+        console.error('휴가 목록 조회 실패:', error)
+        setLeaveList([])
+      }
+    }
+
+    fetchLeaveList()
+  }, [])
+
+  const statusMessageMap: Record<string, string> = {
+    '승인 대기': '휴가 승인 대기 중입니다.',
+    '승인 완료': '휴가 승인이 완료되었습니다.',
+    반려: '휴가 승인이 반려되었습니다.',
+  }
+
   return (
     <section className={S.sideCard}>
       <h3 className={S.sectionTitle}>휴가승인 현황</h3>
 
-      <div className={`${S.listItem} ${S.rejected}`}>
-        <strong>휴가 승인이 반려되었습니다.</strong>
-        <span>2026.04.10 - 2026.04.12</span>
-      </div>
+      {leaveList.slice(0, 3).map((item) => (
+        <div
+          key={item.leaveRequestId}
+          className={`${S.listItem} ${
+            item.approvalStatusName === '승인 완료'
+              ? S.approved
+              : item.approvalStatusName === '반려'
+                ? S.rejected
+                : S.pending
+          }`}
+          onClick={() => navigate('/student/leave')}
+        >
+          <strong>{statusMessageMap[item.approvalStatusName]}</strong>
 
-      <div className={`${S.listItem} ${S.approved}`}>
-        <strong>휴가 승인이 완료되었습니다.</strong>
-        <span>2026.04.10 - 2026.04.10</span>
-      </div>
+          <span>
+            {item.startDate} - {item.endDate}
+          </span>
+        </div>
+      ))}
     </section>
   )
 }

--- a/frontend/src/pages/student/dashboard/components/AttendanceCalendar.tsx
+++ b/frontend/src/pages/student/dashboard/components/AttendanceCalendar.tsx
@@ -2,7 +2,7 @@ import S from '@/pages/student/dashboard/styles/dashboard.module.css'
 
 interface AttendanceCalendarItem {
   attendanceDate: string
-  attendanceStatus: 'PRESENT' | 'LATE' | 'ABSENT' | 'ONGOING'
+  attendanceStatus: 'PRESENT' | 'ABSENT' | 'ONGOING'
 }
 
 interface Props {
@@ -11,7 +11,7 @@ interface Props {
 
 function AttendanceCalendar({ attendanceList }: Props) {
   const year = 2026
-  const month = 5
+  const month = 4
 
   const firstDay = new Date(year, month - 1, 1).getDay()
   const lastDate = new Date(year, month, 0).getDate()
@@ -52,8 +52,7 @@ function AttendanceCalendar({ attendanceList }: Props) {
               className={`${S.day} ${
                 attendance?.attendanceStatus === 'PRESENT'
                   ? S.present
-                  : attendance?.attendanceStatus === 'LATE' ||
-                      attendance?.attendanceStatus === 'ONGOING'
+                  : attendance?.attendanceStatus === 'ONGOING'
                     ? S.ongoing
                     : attendance?.attendanceStatus === 'ABSENT'
                       ? S.absent

--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
   "dependencies": {
-    "axios": "^1.15.2"
+    "axios": "^1.15.2",
+    "jwt-decode": "^4.0.0",
+    "react-loading-skeleton": "^3.5.0"
   }
 }


### PR DESCRIPTION
## 📌 개요

- JWT 기반 학생 대시보드 출결 현황 및  캘린더 API 연동

## 💻 작업 사항

- JWT 기반 학생 대시보드  출결 캘린더, 휴가목록 API 연동
- 기존 하드 코딩  studentId 제거
- Authorization Bearer 토큰 정상 첨부 확인

## 📸 스크린샷 (선택)

  
## 📎 참고 사항 (선택)

  
## 💡 관련 Issue

Closes #

## ✅ 체크리스트

- [ ] 사용하지 않는 코드/파일을 정리했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 기능이 정상 동작하는지 확인했습니다.
