### PR TITLE
refact: 로그인 페이지 Zustand로 리펙토링, 설정 페이지 토큰 리펙토링

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -16,6 +16,7 @@
         "react-loading-skeleton": "^3.5.0",
         "react-quill-new": "^3.8.3",
         "react-router-dom": "^7.14.1",
+        "zustand": "^5.0.13",
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -521,6 +522,8 @@
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
+
+    "zustand": ["zustand@5.0.13", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,8 @@
     "react-icons": "^5.6.0",
     "react-loading-skeleton": "^3.5.0",
     "react-quill-new": "^3.8.3",
-    "react-router-dom": "^7.14.1"
+    "react-router-dom": "^7.14.1",
+    "zustand": "^5.0.13"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/frontend/src/components/common/header/header.tsx
+++ b/frontend/src/components/common/header/header.tsx
@@ -1,5 +1,6 @@
 import { useLocation, useNavigate } from 'react-router-dom'
 import S from './header.module.css'
+import { useAuthStore } from '@/store'
 
 const Title_label: Record<string, Record<string, string>> = {
   student: {
@@ -23,22 +24,23 @@ function Header() {
   const location = useLocation()
   const navigate = useNavigate()
 
+  // Zustand에서 user 정보와 로그아웃 함수 가져오기
+  const { user, setLogout } = useAuthStore()
+
   const pathSegment = location.pathname.split('/')
   const menuRole = pathSegment[1] || 'student'
   const category = pathSegment[2] || 'dashboard'
 
   const pageTitle = Title_label[menuRole]?.[category] || '대시보드'
-
   const subTitle = menuRole === 'admin' ? '관리자님 환영합니다.' : '오늘도 멋사와 함께 열공하세요!'
 
-  // localStorage에서 유저 정보 읽기
-  const userName = localStorage.getItem('userName') || '이름 없음'
-
+  // 로컬스토리지 대신 Zustand 상태 사용
+  const userName = user?.name || '이름 없음'
   const userInitials = menuRole === 'admin' ? '관' : userName ? userName[0] : '학'
 
   // 로그아웃
   const handleLogout = () => {
-    localStorage.clear()
+    setLogout() // Zustand에서 만든 setLogout 실행 (내부에서 localStorage.clear() 자동 수행)
     navigate('/')
   }
 

--- a/frontend/src/pages/admin/settings/api/settingsApi.ts
+++ b/frontend/src/pages/admin/settings/api/settingsApi.ts
@@ -1,8 +1,20 @@
-export const verifyAdminPassword = async (adminId: string, password: string) => {
-  const response = await fetch('https://final-project-team1.onrender.com/api/admin/login', {
+import { useAuthStore } from '@/store'
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL
+
+export const verifyAdminPassword = async (password: string) => {
+  const userId = useAuthStore.getState().user?.userId
+
+  if (!userId) {
+    throw new Error('관리자 정보를 찾을 수 없습니다. 다시 로그인해 주세요.')
+  }
+
+  const response = await fetch(`${BASE_URL}/api/admin/login`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ adminId, password }),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ adminId: userId, password }),
   })
 
   const result = await response.json()
@@ -12,19 +24,16 @@ export const verifyAdminPassword = async (adminId: string, password: string) => 
   return true
 }
 
-export const resetAdminPassword = async (adminId: string, newPassword: string) => {
+export const resetAdminPassword = async (newPassword: string) => {
   const token = localStorage.getItem('accessToken')
-  const response = await fetch(
-    'https://final-project-team1.onrender.com/api/admin/reset-password',
-    {
-      method: 'PATCH',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ adminId, newPassword }),
+  const response = await fetch(`${BASE_URL}/api/admin/reset-password`, {
+    method: 'PATCH',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
     },
-  )
+    body: JSON.stringify({ newPassword }),
+  })
 
   const result = await response.json()
   if (!result.success) {

--- a/frontend/src/pages/admin/settings/hooks/useSettings.ts
+++ b/frontend/src/pages/admin/settings/hooks/useSettings.ts
@@ -3,11 +3,9 @@ import { resetAdminPassword, verifyAdminPassword } from '../api/settingsApi'
 export const useAdminSettings = () => {
   const changePassword = async (currentPassword: string, newPassword: string) => {
     try {
-      const adminId = localStorage.getItem('adminId') || 'admin'
+      await verifyAdminPassword(currentPassword)
 
-      await verifyAdminPassword(adminId, currentPassword)
-
-      await resetAdminPassword(adminId, newPassword)
+      await resetAdminPassword(newPassword)
 
       return { success: true }
     } catch (error) {

--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -7,6 +7,7 @@ import LoginForm from './components/LoginForm'
 import AdminLoginForm from './components/AdminLoginForm'
 import FindPassword from './components/FindPassword'
 import ResetPassword from './components/ResetPassword'
+import { useAuthStore } from '@/store'
 import './styles/login.css'
 
 interface JwtPayload {
@@ -18,6 +19,9 @@ export default function LoginPage() {
   const { view, set_view } = useAuthView()
   const navigate = useNavigate()
 
+  // Zustand 로그아웃 함수 가져오기
+  const setLogout = useAuthStore((state) => state.setLogout)
+
   useEffect(() => {
     const token = localStorage.getItem('accessToken')
 
@@ -28,9 +32,7 @@ export default function LoginPage() {
       const now = Math.floor(new Date().getTime() / 1000)
 
       if (decoded.exp <= now) {
-        localStorage.removeItem('accessToken')
-        localStorage.removeItem('userName')
-        localStorage.removeItem('role')
+        setLogout() // 직접 지우지 말고 스토어 함수 사용!
         return
       }
 
@@ -44,11 +46,9 @@ export default function LoginPage() {
         return
       }
     } catch {
-      localStorage.removeItem('accessToken')
-      localStorage.removeItem('userName')
-      localStorage.removeItem('role')
+      setLogout() // 에러 시에도 스토어 함수 사용
     }
-  }, [navigate])
+  }, [navigate, setLogout]) // 의존성 배열에 setLogout 추가
 
   return (
     <main className="login_page_wrapper">

--- a/frontend/src/pages/auth/api/loginApi.ts
+++ b/frontend/src/pages/auth/api/loginApi.ts
@@ -3,7 +3,7 @@ import axios from 'axios'
 export interface LoginResponseData {
   studentId: string
   name: string
-  role: string
+  role: 'STUDENT' | 'ADMIN'
   isPasswordChangeRequired: string
   accessToken: string
 }

--- a/frontend/src/pages/auth/hooks/useAdminLogin.ts
+++ b/frontend/src/pages/auth/hooks/useAdminLogin.ts
@@ -1,9 +1,12 @@
 import { useState } from 'react'
 import { post_admin_login_api } from '../api/adminLoginApi'
+import { useAuthStore } from '@/store'
 
 export const useAdminLogin = () => {
   const [is_loading, set_is_loading] = useState<boolean>(false)
   const [error_message, set_error_message] = useState<string | null>(null)
+
+  const setLogin = useAuthStore((state) => state.setLogin)
 
   const login_admin = async (adminId: string, password: string) => {
     set_is_loading(true)
@@ -16,6 +19,12 @@ export const useAdminLogin = () => {
       localStorage.setItem('adminId', data.adminId)
       localStorage.setItem('userName', data.name)
       localStorage.setItem('role', data.role)
+
+      setLogin({
+        userId: data.adminId,
+        name: data.name,
+        role: data.role as 'ADMIN', // 관리자 로그인이므로 role은 'ADMIN'으로 고정
+      })
 
       return {
         success: true,

--- a/frontend/src/pages/auth/hooks/useLogin.ts
+++ b/frontend/src/pages/auth/hooks/useLogin.ts
@@ -1,9 +1,12 @@
 import { useState } from 'react'
 import { post_login_api } from '../api/loginApi'
+import { useAuthStore } from '@/store'
 
 export const useLogin = () => {
   const [is_loading, set_is_loading] = useState<boolean>(false)
   const [error_message, set_error_message] = useState<string | null>(null)
+
+  const setLogin = useAuthStore((state) => state.setLogin)
 
   const login_user = async (studentId: string, password: string) => {
     set_is_loading(true)
@@ -11,11 +14,16 @@ export const useLogin = () => {
 
     try {
       const data = await post_login_api(studentId, password)
-
       localStorage.setItem('accessToken', data.accessToken)
       localStorage.setItem('studentId', data.studentId)
       localStorage.setItem('userName', data.name)
       localStorage.setItem('role', data.role)
+
+      setLogin({
+        userId: data.studentId,
+        name: data.name,
+        role: data.role,
+      })
 
       return {
         success: true,

--- a/frontend/src/pages/student/settings/api/settingsApi.ts
+++ b/frontend/src/pages/student/settings/api/settingsApi.ts
@@ -1,3 +1,5 @@
+import { useAuthStore } from '@/store'
+
 export interface StudentProfile {
   name: string
   phoneNumber: string
@@ -12,34 +14,26 @@ interface SettingsResponse {
   data: StudentProfile
 }
 
+const BASE_URL = import.meta.env.VITE_API_BASE_URL
+
 export const fetchStudentProfile = async (studentId: string): Promise<StudentProfile> => {
   const token = localStorage.getItem('accessToken')
 
   const params = new URLSearchParams({ studentId })
 
   try {
-    const response = await fetch(
-      `https://final-project-team1.onrender.com/api/student/settings?${params.toString()}`,
-      {
-        method: 'GET',
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
+    const response = await fetch(`${BASE_URL}/api/student/settings?${params.toString()}`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
       },
-    )
-
-    const contentType = response.headers.get('content-type')
-    if (!contentType || !contentType.includes('application/json')) {
-      throw new Error('서버로부터 올바른 응답(JSON)을 받지 못했습니다.')
-    }
+    })
 
     const result: SettingsResponse = await response.json()
-
     if (!result.success) {
       throw new Error(result.message || '정보 조회 실패')
     }
-
     return result.data
   } catch (error) {
     console.error('학생 상세 조회 실패', error)
@@ -47,37 +41,37 @@ export const fetchStudentProfile = async (studentId: string): Promise<StudentPro
   }
 }
 
-export const verifyCurrentPassword = async (
-  studentId: string,
-  password: string,
-): Promise<boolean> => {
-  const response = await fetch('https://final-project-team1.onrender.com/api/auth/login', {
+export const verifyCurrentPassword = async (password: string): Promise<boolean> => {
+  const userId = useAuthStore.getState().user?.userId
+
+  if (!userId) {
+    throw new Error('사용자 정보를 찾을 수 없습니다. 다시 로그인해 주세요.')
+  }
+
+  const response = await fetch(`${BASE_URL}/api/auth/login`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ studentId, password }),
+    body: JSON.stringify({ studentId: userId, password }),
   })
 
   const result = await response.json()
-
   if (!result.success) {
     throw new Error('현재 비밀번호가 일치하지 않습니다.')
   }
-
   return true
 }
 
-export const updatePassword = async (studentId: string, newPassword: string): Promise<boolean> => {
+export const updatePassword = async (newPassword: string): Promise<boolean> => {
   const token = localStorage.getItem('accessToken')
 
-  const response = await fetch('https://final-project-team1.onrender.com/api/auth/reset-password', {
+  const response = await fetch(`${BASE_URL}/api/auth/reset-password`, {
     method: 'PATCH',
     headers: {
       Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      studentId: studentId,
-      newPassword: newPassword,
+      newPassword,
     }),
   })
 

--- a/frontend/src/pages/student/settings/hooks/useSettings.ts
+++ b/frontend/src/pages/student/settings/hooks/useSettings.ts
@@ -37,12 +37,9 @@ export const useSettings = () => {
 
   const changePassword = async (currentPassword: string, newPassword: string) => {
     try {
-      const savedStudentId = localStorage.getItem('studentId')
-      if (!savedStudentId) throw new Error('로그인 정보가 없습니다.')
+      await verifyCurrentPassword(currentPassword)
 
-      await verifyCurrentPassword(savedStudentId, currentPassword)
-
-      await updatePassword(savedStudentId, newPassword)
+      await updatePassword(newPassword)
 
       return { success: true }
     } catch (error) {

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -1,0 +1,33 @@
+import { create } from 'zustand'
+
+interface UserData {
+  userId?: string
+  name: string
+  role: 'STUDENT' | 'ADMIN'
+}
+
+interface AuthState {
+  isLoggedIn: boolean
+  user: UserData | null
+  setLogin: (userData: UserData) => void
+  setLogout: () => void
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+  isLoggedIn: !!localStorage.getItem('accessToken'),
+
+  // 새로고침해도 이름이 날아가지 않도록 초기값을 로컬스토리지에서 가져옴
+  user: localStorage.getItem('accessToken')
+    ? {
+        userId: localStorage.getItem('adminId') || localStorage.getItem('studentId') || '',
+        name: localStorage.getItem('userName') || '이름 없음',
+        role: (localStorage.getItem('role') as 'STUDENT' | 'ADMIN') || 'STUDENT',
+      }
+    : null,
+
+  setLogin: (userData) => set({ isLoggedIn: true, user: userData }),
+  setLogout: () => {
+    localStorage.clear()
+    set({ isLoggedIn: false, user: null })
+  },
+}))


### PR DESCRIPTION
## 📌 개요

- 로그인 페이지 Zustand로 리펙토링, 설정 페이지 토큰 리펙토링

## 💻 작업 사항

- store/index.ts 에 Zustand 로그인 로직 작성 (필요 시 분리)
- 학생/관리자 로그인 페이지 Zustand 적용
- header.tsx 로그아웃에 Zustand 적용
- 학생/관리자 설정 페이지 JWT 토큰 방식으로 수정
- 설정 페이지에서 토큰 관련 이슈

## 🔁 변경 사항 (재PR 시 작성)

- 수정 또는 보완한 내용을 작성해주세요.

## 📸 스크린샷 (선택)

- 작업한 내용을 남겨주세요.
  
## 📎 참고 사항 (선택)

- 작업한 내용의 참고할 사항을 남겨주세요.
  
## 💡 관련 Issue

Closes #133

## ✅ 체크리스트

- [ ] 관련 이슈를 연결했습니다. (Closes #)
- [ ] 불필요한 console.log를 제거했습니다.
- [ ] 사용하지 않는 코드/파일을 정리했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 기능이 정상 동작하는지 확인했습니다.
