### PR TITLE
refect: 학생/관리자 설정 페이지 비밀번호 변경 api 연결

### DIFF
--- a/frontend/src/pages/admin/settings/api/settingsApi.ts
+++ b/frontend/src/pages/admin/settings/api/settingsApi.ts
@@ -1,8 +1,13 @@
 import { useAuthStore } from '@/store'
 
-const BASE_URL = import.meta.env.VITE_API_BASE_URL
+interface BasicResponse {
+  success: boolean
+  message?: string
+}
 
-export const verifyAdminPassword = async (password: string) => {
+const BASE_URL = import.meta.env.VITE_API_BASE_URL || ''
+
+export const verifyAdminPassword = async (password: string): Promise<boolean> => {
   const userId = useAuthStore.getState().user?.userId
 
   if (!userId) {
@@ -17,16 +22,20 @@ export const verifyAdminPassword = async (password: string) => {
     body: JSON.stringify({ adminId: userId, password }),
   })
 
-  const result = await response.json()
+  const result: BasicResponse = await response.json()
+
   if (!result.success) {
     throw new Error(result.message || '현재 비밀번호가 일치하지 않습니다.')
   }
+
   return true
 }
 
-export const resetAdminPassword = async (newPassword: string) => {
+export const resetAdminPassword = async (newPassword: string): Promise<boolean> => {
   const token = localStorage.getItem('accessToken')
-  const response = await fetch(`${BASE_URL}/api/admin/reset-password`, {
+  const API_URL = `${BASE_URL}/api/admin/reset-password`
+
+  const response = await fetch(API_URL, {
     method: 'PATCH',
     headers: {
       Authorization: `Bearer ${token}`,
@@ -35,9 +44,12 @@ export const resetAdminPassword = async (newPassword: string) => {
     body: JSON.stringify({ newPassword }),
   })
 
-  const result = await response.json()
+  const text = await response.text()
+  const result: BasicResponse = text ? JSON.parse(text) : {}
+
   if (!result.success) {
     throw new Error(result.message || '비밀번호 재설정에 실패했습니다.')
   }
+
   return true
 }

--- a/frontend/src/pages/student/settings/api/settingsApi.ts
+++ b/frontend/src/pages/student/settings/api/settingsApi.ts
@@ -14,6 +14,11 @@ interface SettingsResponse {
   data: StudentProfile
 }
 
+interface BasicResponse {
+  success: boolean
+  message?: string
+}
+
 const BASE_URL = import.meta.env.VITE_API_BASE_URL
 
 export const fetchStudentProfile = async (studentId: string): Promise<StudentProfile> => {
@@ -54,28 +59,27 @@ export const verifyCurrentPassword = async (password: string): Promise<boolean> 
     body: JSON.stringify({ studentId: userId, password }),
   })
 
-  const result = await response.json()
-  if (!result.success) {
-    throw new Error('현재 비밀번호가 일치하지 않습니다.')
-  }
+  const result: BasicResponse = await response.json()
+  if (!result.success) throw new Error('현재 비밀번호가 일치하지 않습니다.')
   return true
 }
 
 export const updatePassword = async (newPassword: string): Promise<boolean> => {
   const token = localStorage.getItem('accessToken')
 
-  const response = await fetch(`${BASE_URL}/api/auth/reset-password`, {
+  const API_URL = `${BASE_URL}/api/student/reset-password`
+
+  const response = await fetch(API_URL, {
     method: 'PATCH',
     headers: {
       Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({
-      newPassword,
-    }),
+    body: JSON.stringify({ newPassword }),
   })
 
-  const result = await response.json()
+  const text = await response.text()
+  const result: BasicResponse = text ? JSON.parse(text) : {}
 
   if (!result.success) {
     throw new Error(result.message || '비밀번호 재설정에 실패했습니다.')


### PR DESCRIPTION
## 📌 개요

- 학생/관리자 설정 페이지 비밀번호 변경 api 연결

## 💻 작업 사항

- 로그인 후 accessToken 사용하여 설정 페이지에서 비밀번호 변경 가능
- Zustand 연결, 비밀번호 유효성 검사

## 🔁 변경 사항 (재PR 시 작성)

- 수정 또는 보완한 내용을 작성해주세요.

## 📸 스크린샷 (선택)

- 작업한 내용을 남겨주세요.
  
## 📎 참고 사항 (선택)

- 작업한 내용의 참고할 사항을 남겨주세요.
  
## 💡 관련 Issue

Closes #133 

## ✅ 체크리스트

- [✅] 관련 이슈를 연결했습니다. (Closes #)
- [✅] 불필요한 console.log를 제거했습니다.
- [✅] 사용하지 않는 코드/파일을 정리했습니다.
- [✅] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [✅] 기능이 정상 동작하는지 확인했습니다.
