### PR TITLE
fix: 로그인 페이지, 설정 페이지 입력창에 스페이스바 불가능하게 변경

### DIFF
--- a/frontend/src/pages/admin/settings/SettingsPage.tsx
+++ b/frontend/src/pages/admin/settings/SettingsPage.tsx
@@ -102,7 +102,7 @@ function AdminSettingPage() {
                   type={showCurrent ? 'text' : 'password'}
                   placeholder="현재 비밀번호를 입력하세요"
                   value={currentPassword}
-                  onChange={(e) => setCurrentPassword(e.target.value)}
+                  onChange={(e) => setCurrentPassword(e.target.value.replace(/\s/g, ''))}
                   className="inputField"
                 />
                 <button
@@ -129,7 +129,7 @@ function AdminSettingPage() {
                   type={showNew ? 'text' : 'password'}
                   placeholder="8~16자, 영문+숫자"
                   value={newPassword}
-                  onChange={(e) => setNewPassword(e.target.value)}
+                  onChange={(e) => setNewPassword(e.target.value.replace(/\s/g, ''))}
                   className="inputField"
                 />
                 <button
@@ -156,7 +156,7 @@ function AdminSettingPage() {
                   type={showConfirm ? 'text' : 'password'}
                   placeholder="새 비밀번호를 다시 입력하세요"
                   value={confirmPassword}
-                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  onChange={(e) => setConfirmPassword(e.target.value.replace(/\s/g, ''))}
                   className="inputField"
                 />
                 <button

--- a/frontend/src/pages/auth/components/AdminLoginForm.tsx
+++ b/frontend/src/pages/auth/components/AdminLoginForm.tsx
@@ -43,7 +43,7 @@ function AdminLoginForm({ onChangeView }: AdminLoginFormProps) {
               placeholder="관리자 아이디를 입력하세요"
               className="input_field"
               value={adminId}
-              onChange={(event) => set_adminId(event.target.value)}
+              onChange={(event) => set_adminId(event.target.value.replace(/\s/g, ''))}
               required
             />
           </label>
@@ -58,7 +58,7 @@ function AdminLoginForm({ onChangeView }: AdminLoginFormProps) {
                 placeholder="비밀번호를 입력하세요"
                 className="input_field"
                 value={password}
-                onChange={(event) => set_password(event.target.value)}
+                onChange={(event) => set_password(event.target.value.replace(/\s/g, ''))}
                 required
               />
               <button

--- a/frontend/src/pages/auth/components/FindPassword.tsx
+++ b/frontend/src/pages/auth/components/FindPassword.tsx
@@ -53,7 +53,7 @@ function FindPassword({ onChangeView }: FindPasswordProps) {
               placeholder="홍길동"
               className="input_field"
               value={name}
-              onChange={(event) => setName(event.target.value)}
+              onChange={(event) => setName(event.target.value.replace(/\s/g, ''))}
               required
             />
           </label>
@@ -67,7 +67,7 @@ function FindPassword({ onChangeView }: FindPasswordProps) {
               placeholder="010-1234-5678"
               className="input_field"
               value={phoneNumber}
-              onChange={(event) => setPhoneNumber(event.target.value)}
+              onChange={(event) => setPhoneNumber(event.target.value.replace(/\s/g, ''))}
               required
             />
           </label>

--- a/frontend/src/pages/auth/components/LoginForm.tsx
+++ b/frontend/src/pages/auth/components/LoginForm.tsx
@@ -53,7 +53,7 @@ function LoginForm({ onChangeView }: LoginFormProps) {
               placeholder="학번을 입력하세요"
               className="input_field"
               value={studentId}
-              onChange={(event) => set_studentId(event.target.value)}
+              onChange={(event) => set_studentId(event.target.value.replace(/\s/g, ''))}
               required
             />
           </label>
@@ -68,7 +68,7 @@ function LoginForm({ onChangeView }: LoginFormProps) {
                 placeholder="비밀번호를 입력하세요"
                 className="input_field"
                 value={password}
-                onChange={(event) => set_password(event.target.value)}
+                onChange={(event) => set_password(event.target.value.replace(/\s/g, ''))}
                 required
               />
               <button

--- a/frontend/src/pages/auth/components/ResetPassword.tsx
+++ b/frontend/src/pages/auth/components/ResetPassword.tsx
@@ -87,7 +87,7 @@ function ResetPassword({ onChangeView }: ResetPasswordProps) {
                 placeholder="비밀번호 8자 이상 영문+숫자 조합"
                 className="input_field"
                 value={new_password}
-                onChange={(event) => set_new_password(event.target.value)}
+                onChange={(event) => set_new_password(event.target.value.replace(/\s/g, ''))}
                 required
               />
               <button
@@ -111,7 +111,7 @@ function ResetPassword({ onChangeView }: ResetPasswordProps) {
                 placeholder="새 비밀번호를 다시 입력하세요"
                 className="input_field"
                 value={confirm_password}
-                onChange={(event) => set_confirm_password(event.target.value)}
+                onChange={(event) => set_confirm_password(event.target.value.replace(/\s/g, ''))}
                 required
               />
               <button

--- a/frontend/src/pages/student/settings/SettingsPage.tsx
+++ b/frontend/src/pages/student/settings/SettingsPage.tsx
@@ -64,19 +64,19 @@ function SettingPage() {
     return (
       <StudentLayout>
         <div className="settingContainer">
-          <Skeleton count={24} width="20%"/>
-          <div style={{display: 'flex', flexDirection: 'column', gap: '12px', marginTop: '16px'}}>
-            <Skeleton height={40}/>
-            <Skeleton height={40}/>
-            <Skeleton height={40}/>
-            <Skeleton height={40}/>
-            <Skeleton height={40}/>
+          <Skeleton count={24} width="20%" />
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', marginTop: '16px' }}>
+            <Skeleton height={40} />
+            <Skeleton height={40} />
+            <Skeleton height={40} />
+            <Skeleton height={40} />
+            <Skeleton height={40} />
           </div>
-          <Skeleton height={24} width="20%" style={{marginTop: '32px'}} />
-          <div style={{display: 'flex', flexDirection: 'column', gap: '12px', marginTop: '16px'}}>
-            <Skeleton height={40}/>
-            <Skeleton height={40}/>
-            <Skeleton height={40}/>
+          <Skeleton height={24} width="20%" style={{ marginTop: '32px' }} />
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', marginTop: '16px' }}>
+            <Skeleton height={40} />
+            <Skeleton height={40} />
+            <Skeleton height={40} />
           </div>
         </div>
       </StudentLayout>
@@ -140,7 +140,7 @@ function SettingPage() {
                   type={showCurrent ? 'text' : 'password'}
                   placeholder="현재 비밀번호를 입력하세요"
                   value={currentPassword}
-                  onChange={(e) => setCurrentPassword(e.target.value)}
+                  onChange={(e) => setCurrentPassword(e.target.value.replace(/\s/g, ''))}
                   className="inputField"
                 />
                 <button
@@ -167,7 +167,7 @@ function SettingPage() {
                   type={showNew ? 'text' : 'password'}
                   placeholder="8~16자, 영문+숫자"
                   value={newPassword}
-                  onChange={(e) => setNewPassword(e.target.value)}
+                  onChange={(e) => setNewPassword(e.target.value.replace(/\s/g, ''))}
                   className="inputField"
                 />
                 <button
@@ -194,7 +194,7 @@ function SettingPage() {
                   type={showConfirm ? 'text' : 'password'}
                   placeholder="새 비밀번호를 다시 입력하세요"
                   value={confirmPassword}
-                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  onChange={(e) => setConfirmPassword(e.target.value.replace(/\s/g, ''))}
                   className="inputField"
                 />
                 <button


### PR DESCRIPTION
## 📌 개요

- 로그인 시 스페이스 바가 입력되면 사용자 경험에 좋지 않음

## 💻 작업 사항

- 로그인 페이지, 설정 페이지 입력 창에 스페이스 바 입력 불가능하게 변경

## 🔁 변경 사항 (재PR 시 작성)

- 수정 또는 보완한 내용을 작성해주세요.

## 📸 스크린샷 (선택)

- 작업한 내용을 남겨주세요.
  
## 📎 참고 사항 (선택)

- 작업한 내용의 참고할 사항을 남겨주세요.
  
## 💡 관련 Issue

Closes #154 

## ✅ 체크리스트

- [✅] 관련 이슈를 연결했습니다. (Closes #)
- [✅] 불필요한 console.log를 제거했습니다.
- [✅] 사용하지 않는 코드/파일을 정리했습니다.
- [✅] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [✅] 기능이 정상 동작하는지 확인했습니다.
