### PR TITLE
fix: 관리자 대시보드 휴가 요청 노출 로직 및 UI 수정

### DIFF
--- a/frontend/src/components/common/header/header.tsx
+++ b/frontend/src/components/common/header/header.tsx
@@ -32,7 +32,26 @@ function Header() {
   const category = pathSegment[2] || 'dashboard'
 
   const pageTitle = Title_label[menuRole]?.[category] || '대시보드'
-  const subTitle = menuRole === 'admin' ? '관리자님 환영합니다.' : '오늘도 멋사와 함께 열공하세요!'
+  // const subTitle = menuRole === 'admin' ? '관리자님 환영합니다.' : '오늘도 멋사와 함께 열공하세요!'
+  let subTitle = '오늘도 멋사와 함께 열공하세요!'
+
+  if (menuRole === 'admin') {
+    if (location.pathname.includes('/admin/student')) {
+      subTitle = '학생 관리 페이지입니다.'
+    } else if (location.pathname.includes('/admin/attendance')) {
+      subTitle = '출결 관리 페이지입니다.'
+    } else if (location.pathname.includes('/admin/lecture')) {
+      subTitle = '강의 관리 페이지입니다.'
+    } else if (location.pathname.includes('/admin/leave')) {
+      subTitle = '휴가 관리 페이지입니다.'
+    } else if (location.pathname.includes('/admin/notice')) {
+      subTitle = '공지사항 관리 페이지입니다.'
+    } else if (location.pathname.includes('/admin/settings')) {
+      subTitle = '환경설정 페이지입니다.'
+    } else {
+      subTitle = '관리자님 환영합니다.'
+    }
+  }
 
   // 로컬스토리지 대신 Zustand 상태 사용
   const userName = user?.name || '이름 없음'

--- a/frontend/src/pages/admin/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/admin/dashboard/DashboardPage.tsx
@@ -19,9 +19,11 @@ import SystemNoticeList from './components/NoticeList'
 import Table, { type TableColumn } from '@/components/common/table'
 import { Button } from '@/components'
 
-import S from '@/pages/admin/dashboard/styles/dashboard.module.css'
+import Skeleton from 'react-loading-skeleton'
+import 'react-loading-skeleton/dist/skeleton.css'
+import TableSkeleton from '@/components/common/skeleton/TableSkeleton'
 
-import Pagination from '@/components/common/pagination/Pagination'
+import S from '@/pages/admin/dashboard/styles/dashboard.module.css'
 
 type VacationType = '병결' | '공결' | '개인사유'
 
@@ -43,39 +45,50 @@ const vacationTypeMap = {
 export default function AdminDashboardPage() {
   const [summary, setSummary] = useState<AdminDashboardData | null>(null)
   const [attendanceData, setAttendanceData] = useState<AttendanceItem[]>([])
-  const [currentPage, setCurrentPage] = useState(1)
 
   const [noticeData, setNoticeData] = useState<NoticeItem[]>([])
 
   const [vacationData, setVacationData] = useState<LeaveRequestItem[]>([])
-  const [leaveTotalCount, setLeaveTotalCount] = useState(0)
+
+  //휴가 신청 현황
+  const [isLeaveLoading, setIsLeaveLoading] = useState(true)
 
   useEffect(() => {
     const fetchLeaveRequestList = async () => {
       try {
-        const data = await getLeaveRequestList(currentPage, pageSize)
+        setIsLeaveLoading(true)
+
+        const data = await getLeaveRequestList(1, 5)
 
         setVacationData(data.items)
-        setLeaveTotalCount(data.totalCount)
       } catch (error) {
         console.error(error)
+      } finally {
+        setIsLeaveLoading(false)
       }
     }
 
     fetchLeaveRequestList()
-  }, [currentPage])
+  }, [])
+
+  //공지사항 리스트
+  const [isNoticeLoading, setIsNoticeLoading] = useState(true)
 
   useEffect(() => {
-    const fetchNoticeList = async () => {
+    const fetchNoticeData = async () => {
       try {
+        setIsNoticeLoading(true)
+
         const data = await getNoticeList()
         setNoticeData(data)
       } catch (error) {
         console.error(error)
+      } finally {
+        setIsNoticeLoading(false)
       }
     }
 
-    fetchNoticeList()
+    fetchNoticeData()
   }, [])
 
   useEffect(() => {
@@ -91,13 +104,20 @@ export default function AdminDashboardPage() {
     fetchSummary()
   }, [])
 
+  //전체 출결 현황 그래프
+  const [isLoading, setIsLoading] = useState(true)
+
   useEffect(() => {
     const fetchAttendanceData = async () => {
       try {
+        setIsLoading(true)
+
         const data = await getAttendanceStatusByClass()
         setAttendanceData(data)
       } catch (error) {
         console.error(error)
+      } finally {
+        setIsLoading(false)
       }
     }
 
@@ -108,10 +128,9 @@ export default function AdminDashboardPage() {
     try {
       await updateLeaveRequestStatus(row.leaveRequestId, 'V002')
 
-      const data = await getLeaveRequestList(currentPage, pageSize)
+      const data = await getLeaveRequestList(1, 5)
 
       setVacationData(data.items)
-      setLeaveTotalCount(data.totalCount)
     } catch (error) {
       console.error(error)
     }
@@ -121,17 +140,13 @@ export default function AdminDashboardPage() {
     try {
       await updateLeaveRequestStatus(row.leaveRequestId, 'V003')
 
-      const data = await getLeaveRequestList(currentPage, pageSize)
+      const data = await getLeaveRequestList(1, 5)
 
       setVacationData(data.items)
-      setLeaveTotalCount(data.totalCount)
     } catch (error) {
       console.error(error)
     }
   }
-
-  const pageSize = 10
-  const totalPages = Math.ceil(leaveTotalCount / pageSize)
 
   const vacationColumns: TableColumn<LeaveRequestItem>[] = [
     {
@@ -240,13 +255,27 @@ export default function AdminDashboardPage() {
         <div className={S.topGrid}>
           <section className={S.chartSection}>
             <div className={S.container}>
-              <AttendanceStatusChart data={attendanceData} />
+              {isLoading ? (
+                <>
+                  <Skeleton width={180} height={24} borderRadius={8} />
+
+                  <div style={{ marginTop: '24px' }}>
+                    <Skeleton height={280} borderRadius={16} />
+                  </div>
+                </>
+              ) : (
+                <AttendanceStatusChart data={attendanceData} />
+              )}
             </div>
           </section>
 
           <section className={S.noticeSection}>
             <div className={S.container}>
-              <SystemNoticeList data={noticeData} />
+              {isNoticeLoading ? (
+                <TableSkeleton rows={5} columns={2} />
+              ) : (
+                <SystemNoticeList data={noticeData} />
+              )}
             </div>
           </section>
         </div>
@@ -254,22 +283,16 @@ export default function AdminDashboardPage() {
         <section className={S.recentLeave}>
           <h3>최근 휴가 신청 내역</h3>
 
-          <Table
-            columns={vacationColumns}
-            data={vacationData}
-            totalCount={leaveTotalCount}
-            currentPage={currentPage}
-            pageSize={pageSize}
-            countLabel="명"
-          />
-
-          <div className={S.paginationBox}>
-            <Pagination
-              currentPage={currentPage}
-              totalPages={totalPages}
-              onPageChange={setCurrentPage}
+          {isLeaveLoading ? (
+            <TableSkeleton rows={5} columns={vacationColumns.length} />
+          ) : (
+            <Table
+              columns={vacationColumns}
+              data={vacationData.slice(0, 5)}
+              totalCount={5}
+              countLabel="명"
             />
-          </div>
+          )}
         </section>
       </div>
     </AdminLayout>

--- a/frontend/src/pages/admin/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/admin/dashboard/DashboardPage.tsx
@@ -58,9 +58,9 @@ export default function AdminDashboardPage() {
       try {
         setIsLeaveLoading(true)
 
-        const data = await getLeaveRequestList(1, 5)
+        const data = await getLeaveRequestList(1, 100)
 
-        setVacationData(data.items)
+        setVacationData(data.items.filter((item) => item.approvalStatusCode === 'V001').slice(0, 5))
       } catch (error) {
         console.error(error)
       } finally {
@@ -128,9 +128,9 @@ export default function AdminDashboardPage() {
     try {
       await updateLeaveRequestStatus(row.leaveRequestId, 'V002')
 
-      const data = await getLeaveRequestList(1, 5)
+      const data = await getLeaveRequestList(1, 100)
 
-      setVacationData(data.items)
+      setVacationData(data.items.filter((item) => item.approvalStatusCode === 'V001').slice(0, 5))
     } catch (error) {
       console.error(error)
     }
@@ -140,9 +140,9 @@ export default function AdminDashboardPage() {
     try {
       await updateLeaveRequestStatus(row.leaveRequestId, 'V003')
 
-      const data = await getLeaveRequestList(1, 5)
+      const data = await getLeaveRequestList(1, 100)
 
-      setVacationData(data.items)
+      setVacationData(data.items.filter((item) => item.approvalStatusCode === 'V001').slice(0, 5))
     } catch (error) {
       console.error(error)
     }
@@ -183,26 +183,14 @@ export default function AdminDashboardPage() {
       key: 'action',
       header: '처리',
       render: (row) => {
-        const isCompleted = row.approvalStatusCode !== 'V001'
-
         return (
           <div className={S.actionBox}>
-            <Button
-              type="button"
-              variant="active"
-              disabled={isCompleted}
-              onClick={() => handleApprove(row)}
-            >
+            <Button type="button" variant="active" onClick={() => handleApprove(row)}>
               <Check size={16} />
               승인
             </Button>
 
-            <Button
-              type="button"
-              variant="inactive"
-              disabled={isCompleted}
-              onClick={() => handleReject(row)}
-            >
+            <Button type="button" variant="inactive" onClick={() => handleReject(row)}>
               <X size={16} />
               반려
             </Button>


### PR DESCRIPTION
## 📌 개요

- 관리자 대시보드 내 휴가 요청 목록 노출 로직 수정 및 UI 수정

## 💻 작업 사항

- 승인 대기 상태(V001)의 휴가 요청만 노출되도록 수정
- 휴가 대기건 중 최신 5건만 표시되도록 로직 수정
- 휴가 처리 완료건은 노출되지 않도록 수정
- 관리자 페이지별 헤더 안내 문구 분기 처리 추가
- 페이지 네이션 제거
- 스켈레톤 UI 추가

## 📸 스크린샷 (선택)

  
## 📎 참고 사항 (선택)

  
## 💡 관련 Issue

Closes #

## ✅ 체크리스트

- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
