### PR TITLE
Feat: 관리자 대시보드 UI 및 출결 표시 로직 개선

### DIFF
--- a/frontend/src/pages/admin/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/admin/dashboard/DashboardPage.tsx
@@ -124,6 +124,7 @@ export default function AdminDashboardPage() {
     fetchAttendanceData()
   }, [])
 
+  //휴가 신청 승인/반려
   const handleApprove = async (row: LeaveRequestItem) => {
     try {
       await updateLeaveRequestStatus(row.leaveRequestId, 'V002')
@@ -213,7 +214,7 @@ export default function AdminDashboardPage() {
           />
           <CountCard
             label="출석완료"
-            value={summary?.presentCount ?? 0}
+            value={(summary?.presentCount ?? 0) + (summary?.lateCount ?? 0)}
             unit="명"
             icon={<UserCheck />}
             variant="green"

--- a/frontend/src/pages/admin/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/admin/dashboard/DashboardPage.tsx
@@ -269,7 +269,10 @@ export default function AdminDashboardPage() {
         </div>
 
         <section className={S.recentLeave}>
-          <h3>최근 휴가 신청 내역</h3>
+          <div className={S.header}>
+            <h3>최근 휴가 신청 내역</h3>
+            <p className={S.description}>최근 등록된 5개 내역만 표시됩니다.</p>
+          </div>
 
           {isLeaveLoading ? (
             <TableSkeleton rows={5} columns={vacationColumns.length} />

--- a/frontend/src/pages/admin/dashboard/components/AttendanceStatusChart.tsx
+++ b/frontend/src/pages/admin/dashboard/components/AttendanceStatusChart.tsx
@@ -16,7 +16,11 @@ interface Props {
 export default function AttendanceStatusChart({ data }: Props) {
   return (
     <section className={S.attendanceChartSection}>
-      <h3 className={S.sectionTitle}>오늘의 전체 출결 현황</h3>
+      <div className={S.header}>
+        <h3 className={S.sectionTitle}>오늘의 전체 출결 현황</h3>
+
+        <p className={S.description}>현재 진행중인 강의만 표시됩니다.</p>
+      </div>
 
       <div className={S.chartList}>
         {data.map((item) => {

--- a/frontend/src/pages/admin/dashboard/components/AttendanceStatusChart.tsx
+++ b/frontend/src/pages/admin/dashboard/components/AttendanceStatusChart.tsx
@@ -30,6 +30,8 @@ export default function AttendanceStatusChart({ data }: Props) {
           const latePercent = total ? (item.lateCount / total) * 100 : 0
           const absentPercent = total ? (item.absentCount / total) * 100 : 0
 
+          const actualPresentCount = item.presentCount + item.lateCount
+
           return (
             <div key={item.classId} className={S.chartItem}>
               <div className={S.chartHeader}>
@@ -44,7 +46,7 @@ export default function AttendanceStatusChart({ data }: Props) {
               </div>
 
               <div className={S.legend}>
-                <span className={S.presentDot}>출석완료 {item.presentCount}명</span>
+                <span className={S.presentDot}>출석완료 {actualPresentCount}명</span>
                 <span className={S.lateDot}>지각인원 {item.lateCount}명</span>
                 <span className={S.absentDot}>결석인원 {item.absentCount}명</span>
               </div>

--- a/frontend/src/pages/admin/dashboard/components/NoticeList.tsx
+++ b/frontend/src/pages/admin/dashboard/components/NoticeList.tsx
@@ -23,7 +23,14 @@ export default function NoticeList({ data }: Props) {
             className={S.item}
             onClick={() => navigate(`/admin/notice/${item.noticeId}`)}
           >
-            <strong className={S.noticeTitle}>{item.title}</strong>
+            <div className={S.noticeContent}>
+              <strong className={S.noticeTitle}>{item.title}</strong>
+
+              <span className={item.isOpen ? S.publicBadge : S.privateBadge}>
+                {item.isOpen ? '공개' : '비공개'}
+              </span>
+            </div>
+
             <span className={S.noticeDate}>{item.createdDate}</span>
           </li>
         ))}

--- a/frontend/src/pages/admin/dashboard/components/NoticeList.tsx
+++ b/frontend/src/pages/admin/dashboard/components/NoticeList.tsx
@@ -10,7 +10,11 @@ export default function NoticeList({ data }: Props) {
   const navigate = useNavigate()
   return (
     <>
-      <h3 className={S.title}>시스템 공지사항</h3>
+      <div className={S.header}>
+        <h3 className={S.title}>시스템 공지사항</h3>
+
+        <p className={S.description}>최근 등록된 공지사항 5개 내역만 표시됩니다.</p>
+      </div>
 
       <ul className={S.list}>
         {data.slice(0, 5).map((item) => (

--- a/frontend/src/pages/admin/dashboard/components/NoticeList.tsx
+++ b/frontend/src/pages/admin/dashboard/components/NoticeList.tsx
@@ -13,10 +13,10 @@ export default function NoticeList({ data }: Props) {
       <h3 className={S.title}>시스템 공지사항</h3>
 
       <ul className={S.list}>
-        {data.slice(0, 5).map((item, index) => (
+        {data.slice(0, 5).map((item) => (
           <li
             key={item.noticeId}
-            className={`${S.item} ${index === 0 ? S.highlight : ''}`}
+            className={S.item}
             onClick={() => navigate(`/admin/notice/${item.noticeId}`)}
           >
             <strong className={S.noticeTitle}>{item.title}</strong>

--- a/frontend/src/pages/admin/dashboard/styles/dashboard.module.css
+++ b/frontend/src/pages/admin/dashboard/styles/dashboard.module.css
@@ -52,22 +52,16 @@
 }
 
 .item:hover {
-  background: #f2f2f2;
-}
+  background-color: #fff7ed;
+  border-color: #fdba74;
 
-.highlight {
-  background: #fff3eb;
-  border-color: #ff5a00;
+  cursor: pointer;
 }
 
 .noticeTitle {
   font-weight: 700;
   font-size: 16px;
   color: #333333;
-}
-
-.highlight .noticeTitle {
-  color: #ff5a00;
 }
 
 .noticeDate {
@@ -326,9 +320,4 @@
 
 .absentDot::before {
   background: #e60000;
-}
-
-.highlight {
-  background: #fff3eb;
-  border: 2px solid #ffb48a;
 }

--- a/frontend/src/pages/admin/dashboard/styles/dashboard.module.css
+++ b/frontend/src/pages/admin/dashboard/styles/dashboard.module.css
@@ -11,7 +11,7 @@
 }
 
 .title {
-  margin: 0 0 28px;
+  margin: 0 0 3px;
 
   font-weight: 700;
   font-size: 20px;
@@ -232,7 +232,7 @@
 }
 
 .sectionTitle {
-  margin: 0 0 18px;
+  margin: 0 0 3px;
 
   font-weight: 600;
   font-size: 22px;
@@ -320,4 +320,20 @@
 
 .absentDot::before {
   background: #e60000;
+}
+
+/* 섹션별 부가 설명 */
+.header {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  margin-bottom: 10px;
+}
+
+.description {
+  margin-top: 4px;
+
+  font-size: 14px;
+  color: #9ca3af;
+  text-align: left;
 }

--- a/frontend/src/pages/admin/dashboard/styles/dashboard.module.css
+++ b/frontend/src/pages/admin/dashboard/styles/dashboard.module.css
@@ -337,3 +337,40 @@
   color: #9ca3af;
   text-align: left;
 }
+
+/* 공지사항 공개/비공개 */
+/* 공지사항 공개/비공개 */
+.noticeContent {
+  display: flex;
+  align-items: center;
+
+  width: 100%;
+  gap: 10px;
+}
+
+.publicBadge,
+.privateBadge {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  min-height: 22px;
+  padding: 2px 8px;
+  margin-left: auto;
+
+  border-radius: 6px;
+
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.publicBadge {
+  background-color: #ecfdf3;
+  color: #027a48;
+}
+
+.privateBadge {
+  background-color: #f2f4f7;
+  color: #667085;
+}


### PR DESCRIPTION
## 📌 개요

- 관리자 대시보드 UI 및 출결 표시 로직 개선

## 💻 작업 사항

- 시스템 공지사항 hover 하이라이트 제거 및 색상 수정
- 관리자 대시보드 섹션별 부가 설명 추가
- 공지사항 공개 여부 배지 스타일 적용
- 지각 인원을 포함도록 출석 완료 인원 표시 로직 수정

## 📸 스크린샷 (선택)

<img width="1593" height="935" alt="image" src="https://github.com/user-attachments/assets/9453a07a-5a21-4f0c-ab6b-897ceb189a7d" />
  
## 📎 참고 사항 (선택)

  
## 💡 관련 Issue

Closes #

## ✅ 체크리스트

- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
