### PR TITLE
feat: 관리자 대시보드 출결 차트 및 휴가 신청 내역 랜딩 속도 개선

### DIFF
--- a/frontend/src/pages/admin/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/admin/dashboard/DashboardPage.tsx
@@ -50,6 +50,8 @@ export default function AdminDashboardPage() {
 
   const [vacationData, setVacationData] = useState<LeaveRequestItem[]>([])
 
+  const [processingId, setProcessingId] = useState<number | null>(null)
+
   //휴가 신청 현황
   const [isLeaveLoading, setIsLeaveLoading] = useState(true)
 
@@ -62,7 +64,6 @@ export default function AdminDashboardPage() {
 
         setVacationData(data.items.filter((item) => item.approvalStatusCode === 'V001').slice(0, 5))
       } catch (error) {
-        console.error(error)
       } finally {
         setIsLeaveLoading(false)
       }
@@ -82,7 +83,6 @@ export default function AdminDashboardPage() {
         const data = await getNoticeList()
         setNoticeData(data)
       } catch (error) {
-        console.error(error)
       } finally {
         setIsNoticeLoading(false)
       }
@@ -91,61 +91,59 @@ export default function AdminDashboardPage() {
     fetchNoticeData()
   }, [])
 
-  useEffect(() => {
-    const fetchSummary = async () => {
-      try {
-        const data = await getAdminDashboardSummary()
-        setSummary(data)
-      } catch (error) {
-        console.error(error)
-      }
-    }
-
-    fetchSummary()
-  }, [])
-
-  //전체 출결 현황 그래프
+  //출결 현황 그래프
   const [isLoading, setIsLoading] = useState(true)
-
   useEffect(() => {
-    const fetchAttendanceData = async () => {
+    const fetchDashboardData = async () => {
       try {
         setIsLoading(true)
 
-        const data = await getAttendanceStatusByClass()
-        setAttendanceData(data)
+        const [summaryData, attendanceData] = await Promise.all([
+          getAdminDashboardSummary(),
+          getAttendanceStatusByClass(),
+        ])
+
+        setSummary(summaryData)
+        setAttendanceData(attendanceData)
       } catch (error) {
-        console.error(error)
       } finally {
         setIsLoading(false)
       }
     }
 
-    fetchAttendanceData()
+    fetchDashboardData()
   }, [])
 
   //휴가 신청 승인/반려
   const handleApprove = async (row: LeaveRequestItem) => {
     try {
+      setProcessingId(row.leaveRequestId)
+
       await updateLeaveRequestStatus(row.leaveRequestId, 'V002')
 
-      const data = await getLeaveRequestList(1, 100)
+      const data = await getLeaveRequestList(1, 50)
 
       setVacationData(data.items.filter((item) => item.approvalStatusCode === 'V001').slice(0, 5))
     } catch (error) {
       console.error(error)
+    } finally {
+      setProcessingId(null)
     }
   }
 
   const handleReject = async (row: LeaveRequestItem) => {
     try {
+      setProcessingId(row.leaveRequestId)
+
       await updateLeaveRequestStatus(row.leaveRequestId, 'V003')
 
-      const data = await getLeaveRequestList(1, 100)
+      const data = await getLeaveRequestList(1, 50)
 
       setVacationData(data.items.filter((item) => item.approvalStatusCode === 'V001').slice(0, 5))
     } catch (error) {
       console.error(error)
+    } finally {
+      setProcessingId(null)
     }
   }
 
@@ -186,14 +184,24 @@ export default function AdminDashboardPage() {
       render: (row) => {
         return (
           <div className={S.actionBox}>
-            <Button type="button" variant="active" onClick={() => handleApprove(row)}>
+            <Button
+              type="button"
+              variant="active"
+              onClick={() => handleApprove(row)}
+              disabled={processingId === row.leaveRequestId}
+            >
               <Check size={16} />
-              승인
+              {processingId === row.leaveRequestId ? '...' : '승인'}
             </Button>
 
-            <Button type="button" variant="inactive" onClick={() => handleReject(row)}>
+            <Button
+              type="button"
+              variant="inactive"
+              onClick={() => handleReject(row)}
+              disabled={processingId === row.leaveRequestId}
+            >
               <X size={16} />
-              반려
+              {processingId === row.leaveRequestId ? '...' : '반려'}
             </Button>
           </div>
         )

--- a/frontend/src/pages/admin/dashboard/api/dashboardApi.ts
+++ b/frontend/src/pages/admin/dashboard/api/dashboardApi.ts
@@ -13,9 +13,6 @@ export interface AdminDashboardData {
 export async function getAdminDashboardSummary() {
   const response = await api.get('/api/admin/dashboard')
 
-  console.log('전체 응답:', response)
-  console.log('response.data:', response.data)
-
   return response.data.data
 }
 
@@ -30,10 +27,6 @@ export interface AttendanceItem {
 
 export async function getAttendanceStatusByClass() {
   const response = await api.get('/api/admin/classes/attendance')
-
-  console.log('강의별 출결 응답:', response)
-  console.log('response.data:', response.data)
-
   return response.data.data
 }
 


### PR DESCRIPTION
## 📌 개요

- 관리자 대시보드 출결 차트 및 휴가 신청 내역 랜딩 속도 개선

## 💻 작업 사항

- 관리자 대시보드 출결 차트 및 휴가 신청 내역 랜딩 속도 개선

## 📸 스크린샷 (선택)

  
## 📎 참고 사항 (선택)


## 💡 관련 Issue

Closes #

## ✅ 체크리스트

- [x] 불필요한 console.log를 제거했습니다.
- [x] 사용하지 않는 코드/파일을 정리했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
