### PR TITLE
fix: axios - adminId 가 남아있는 오류 수정

### DIFF
--- a/frontend/src/api/axios.ts
+++ b/frontend/src/api/axios.ts
@@ -38,10 +38,7 @@ axiosInstance.interceptors.response.use(
   (response) => response,
   (error) => {
     if (error.response?.status === 401) {
-      localStorage.removeItem('accessToken')
-      localStorage.removeItem('userName')
-      localStorage.removeItem('studentId')
-      localStorage.removeItem('role')
+      localStorage.clear()
       window.location.href = '/'
     }
     return Promise.reject(error)

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -16,7 +16,6 @@ interface AuthState {
 export const useAuthStore = create<AuthState>((set) => ({
   isLoggedIn: !!localStorage.getItem('accessToken'),
 
-  // 새로고침해도 이름이 날아가지 않도록 초기값을 로컬스토리지에서 가져옴
   user: localStorage.getItem('accessToken')
     ? {
         userId: localStorage.getItem('adminId') || localStorage.getItem('studentId') || '',
@@ -26,6 +25,7 @@ export const useAuthStore = create<AuthState>((set) => ({
     : null,
 
   setLogin: (userData) => set({ isLoggedIn: true, user: userData }),
+  
   setLogout: () => {
     localStorage.clear()
     set({ isLoggedIn: false, user: null })


### PR DESCRIPTION
## 📌 개요

- axios에서 로컬스토리지를 비울 때 adminId는 남아있던 오류 수정

## 💻 작업 사항

- axios 에서 로컬스토리지를 비우는 로직을 clear 로 전부 지우는 걸로 변경

## 🔁 변경 사항 (재PR 시 작성)

- 수정 또는 보완한 내용을 작성해주세요.

## 📸 스크린샷 (선택)

- 작업한 내용을 남겨주세요.
  
## 📎 참고 사항 (선택)

- 작업한 내용의 참고할 사항을 남겨주세요.
  
## 💡 관련 Issue

Closes #184 

## ✅ 체크리스트

- [✅] 관련 이슈를 연결했습니다. (Closes #)
- [✅] 불필요한 console.log를 제거했습니다.
- [✅] 사용하지 않는 코드/파일을 정리했습니다.
- [✅] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [✅] 기능이 정상 동작하는지 확인했습니다.
