### PR TITLE
refact: localStorage 항목 최소화 및 Zustand 레거시 코드 정리

### DIFF
--- a/frontend/src/pages/auth/hooks/useAdminLogin.ts
+++ b/frontend/src/pages/auth/hooks/useAdminLogin.ts
@@ -16,9 +16,11 @@ export const useAdminLogin = () => {
       const data = await postAdminLoginApi(adminId, password)
 
       localStorage.setItem('accessToken', data.accessToken)
-      localStorage.setItem('adminId', data.adminId)
       localStorage.setItem('userName', data.name)
-      localStorage.setItem('role', data.role)
+      // 변경 전: userId/role을 localStorage에 직접 저장했으나 보안상 제거
+      // localStorage.setItem('adminId', data.adminId)
+      // localStorage.setItem('role', data.role)
+      // → 새로고침 시 store/index.ts에서 accessToken을 디코딩해 복원
 
       setLogin({
         userId: data.adminId,

--- a/frontend/src/pages/auth/hooks/useLogin.ts
+++ b/frontend/src/pages/auth/hooks/useLogin.ts
@@ -15,9 +15,11 @@ export const useLogin = () => {
     try {
       const data = await postLoginApi(studentId, password)
       localStorage.setItem('accessToken', data.accessToken)
-      localStorage.setItem('studentId', data.studentId)
       localStorage.setItem('userName', data.name)
-      localStorage.setItem('role', data.role)
+      // 변경 전: userId/role을 localStorage에 직접 저장했으나 보안상 제거
+      // localStorage.setItem('studentId', data.studentId)
+      // localStorage.setItem('role', data.role)
+      // → 새로고침 시 store/index.ts에서 accessToken을 디코딩해 복원
 
       setLogin({
         userId: data.studentId,

--- a/frontend/src/pages/student/leave/LeaveListPage.tsx
+++ b/frontend/src/pages/student/leave/LeaveListPage.tsx
@@ -9,6 +9,7 @@ import type { TableColumn } from '@/components/common/table/table.types'
 import { Plus } from 'lucide-react'
 import { getLeaveList } from './api/leaveApi'
 import type { LeaveItem } from './api/leaveApi'
+import { useAuthStore } from '@/store'
 import S from './styles/leave.module.css'
 
 const statusMap: Record<string, { className: string }> = {
@@ -25,7 +26,8 @@ function LeaveListPage() {
   const [leaveList, setLeaveList] = useState<LeaveItem[]>([])
   const [totalCount, setTotalCount] = useState(0)
 
-  const studentId = localStorage.getItem('studentId') || ''
+  // 변경 전: localStorage.getItem('studentId') || ''
+  const studentId = useAuthStore((state) => state.user?.userId) || ''
   const totalPages = Math.ceil(totalCount / 10)
 
   useEffect(() => {

--- a/frontend/src/pages/student/leave/request/LeaveRequestPage.tsx
+++ b/frontend/src/pages/student/leave/request/LeaveRequestPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { postLeaveRequest } from '../api/leaveApi'
+import { useAuthStore } from '@/store'
 import StudentLayout from '@/pages/sample/StudentLayout'
 import Button from '@/components/common/button/ui/button'
 import CustomComboBox from '@/components/common/comboBox/customComboBox'
@@ -42,6 +43,8 @@ function getToday(): Date {
 
 function LeaveRequestPage() {
   const navigate = useNavigate()
+  // 변경 전: localStorage.getItem('studentId') || ''
+  const studentId = useAuthStore((state) => state.user?.userId) || ''
 
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [startDate, setStartDate] = useState<Date | null>(null)
@@ -79,7 +82,7 @@ function LeaveRequestPage() {
     try {
       setIsSubmitting(true)
       await postLeaveRequest({
-        studentId: localStorage.getItem('studentId') || '',
+        studentId,
         leaveTypeCode: LEAVE_TYPE_CODE_MAP[leaveType],
         startDate: formatDate(startDate),
         endDate: formatDate(endDate),

--- a/frontend/src/pages/student/settings/hooks/useSettings.ts
+++ b/frontend/src/pages/student/settings/hooks/useSettings.ts
@@ -5,6 +5,7 @@ import {
   updatePassword,
   type StudentProfile,
 } from '../api/settingsApi'
+import { useAuthStore } from '@/store'
 
 export const useSettings = () => {
   const [profile, setProfile] = useState<StudentProfile | null>(null)
@@ -16,7 +17,8 @@ export const useSettings = () => {
       try {
         setIsLoading(true)
 
-        const savedStudentId = localStorage.getItem('studentId')
+        // 변경 전: localStorage.getItem('studentId')
+        const savedStudentId = useAuthStore.getState().user?.userId
 
         if (!savedStudentId) {
           throw new Error('로그인 정보가 없습니다. 다시 로그인해 주세요.')

--- a/frontend/src/routes/ProtectedRoute.tsx
+++ b/frontend/src/routes/ProtectedRoute.tsx
@@ -1,5 +1,6 @@
 import { Navigate, Outlet } from 'react-router-dom'
 import { jwtDecode } from 'jwt-decode'
+import { useAuthStore } from '@/store'
 
 interface JwtPayload {
   exp: number
@@ -12,14 +13,9 @@ interface ProtectedRouteProps {
 
 export default function ProtectedRoute({ allowedRole }: ProtectedRouteProps) {
   const token = localStorage.getItem('accessToken')
+  // localStorage를 직접 조작하는 대신 Zustand setLogout으로 상태 + localStorage 일괄 초기화
+  const setLogout = useAuthStore.getState().setLogout
 
-  function clearAuth() {
-    localStorage.removeItem('accessToken')
-    localStorage.removeItem('userName')
-    localStorage.removeItem('role')
-  }
-
-  // 토큰 없음
   if (!token) {
     return <Navigate to="/" replace />
   }
@@ -29,30 +25,26 @@ export default function ProtectedRoute({ allowedRole }: ProtectedRouteProps) {
   try {
     decoded = jwtDecode<JwtPayload>(token)
   } catch {
-    clearAuth()
-
+    // 토큰 파싱 실패
+    setLogout()
     return <Navigate to="/" replace />
   }
 
-  // decode 실패 방어
   if (!decoded) {
-    clearAuth()
-
+    setLogout()
     return <Navigate to="/" replace />
   }
 
-  // 현재 시간
   const now = Math.floor(new Date().getTime() / 1000)
 
-  // 토큰 만료
   if (decoded.exp < now) {
-    clearAuth()
-
+    // 토큰 만료
+    setLogout()
     return <Navigate to="/" replace />
   }
 
-  // 권한 불일치
   if (decoded.role !== allowedRole) {
+    // 권한 불일치
     return <Navigate to="/" replace />
   }
 

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -1,4 +1,12 @@
 import { create } from 'zustand'
+import { jwtDecode } from 'jwt-decode'
+
+interface JwtPayload {
+  sub: string
+  role: 'STUDENT' | 'ADMIN'
+  iat: number
+  exp: number
+}
 
 interface UserData {
   userId?: string
@@ -13,19 +21,36 @@ interface AuthState {
   setLogout: () => void
 }
 
+// 변경 전: localStorage에서 직접 userId/role을 읽어 초기화했으나
+// 보안상 민감한 키(adminId, studentId, role)를 localStorage에 노출하지 않기 위해
+// accessToken을 디코딩해 userId와 role을 복원하는 방식으로 변경
+// 변경 전 코드:
+// user: localStorage.getItem('accessToken')
+//   ? {
+//       userId: localStorage.getItem('adminId') || localStorage.getItem('studentId') || '',
+//       name: localStorage.getItem('userName') || '이름 없음',
+//       role: (localStorage.getItem('role') as 'STUDENT' | 'ADMIN') || 'STUDENT',
+//     }
+//   : null,
+function getUserFromToken(): UserData | null {
+  const token = localStorage.getItem('accessToken')
+  if (!token) return null
+  try {
+    const decoded = jwtDecode<JwtPayload>(token)
+    return {
+      userId: decoded.sub,
+      name: localStorage.getItem('userName') || '이름 없음',
+      role: decoded.role,
+    }
+  } catch {
+    return null
+  }
+}
+
 export const useAuthStore = create<AuthState>((set) => ({
   isLoggedIn: !!localStorage.getItem('accessToken'),
-
-  user: localStorage.getItem('accessToken')
-    ? {
-        userId: localStorage.getItem('adminId') || localStorage.getItem('studentId') || '',
-        name: localStorage.getItem('userName') || '이름 없음',
-        role: (localStorage.getItem('role') as 'STUDENT' | 'ADMIN') || 'STUDENT',
-      }
-    : null,
-
+  user: getUserFromToken(),
   setLogin: (userData) => set({ isLoggedIn: true, user: userData }),
-  
   setLogout: () => {
     localStorage.clear()
     set({ isLoggedIn: false, user: null })


### PR DESCRIPTION
## 📌 개요

- localStorage 항목 최소화 및 Zustand 레거시 코드 정리

## 💻 작업 사항

- localStorage 최소화 - accessToken + userName 두 개만 남기고 JWT 디코딩으로 복원
ㄴ accessToken - API 요청마다 필요해서 유지
ㄴ userName - JWT에 name 클레임이 없어서 유지
(새로고침 시엔 accessToken을 디코딩해서 복원)
ㄴ LeaveRequestPage.tsx, LeaveListPage.tsx 변경 전 코드 주석으로 표시

- Zustand 레거시 정리 — ProtectedRoute 포함 전체 auth 관련 코드 통일

## 🔁 변경 사항 (재PR 시 작성)

- 수정 또는 보완한 내용을 작성해주세요.

## 📸 스크린샷 (선택)

- 작업한 내용을 남겨주세요.
  
## 📎 참고 사항 (선택)

- 작업한 내용의 참고할 사항을 남겨주세요.
  
## 💡 관련 Issue

Closes #200 

## ✅ 체크리스트

- [✅] 관련 이슈를 연결했습니다. (Closes #)
- [✅] 불필요한 console.log를 제거했습니다.
- [✅] 사용하지 않는 코드/파일을 정리했습니다.
- [✅] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [✅] 기능이 정상 동작하는지 확인했습니다.
