### PR TITLE
fix: 관리자용 대시보드 휴가 신청 내역 size 축소

### DIFF
--- a/frontend/src/pages/admin/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/admin/dashboard/DashboardPage.tsx
@@ -60,7 +60,7 @@ export default function AdminDashboardPage() {
       try {
         setIsLeaveLoading(true)
 
-        const data = await getLeaveRequestList(1, 100)
+        const data = await getLeaveRequestList(1, 30)
 
         setVacationData(data.items.filter((item) => item.approvalStatusCode === 'V001').slice(0, 5))
       } catch (error) {
@@ -121,7 +121,7 @@ export default function AdminDashboardPage() {
 
       await updateLeaveRequestStatus(row.leaveRequestId, 'V002')
 
-      const data = await getLeaveRequestList(1, 50)
+      const data = await getLeaveRequestList(1, 30)
 
       setVacationData(data.items.filter((item) => item.approvalStatusCode === 'V001').slice(0, 5))
     } catch (error) {
@@ -137,7 +137,7 @@ export default function AdminDashboardPage() {
 
       await updateLeaveRequestStatus(row.leaveRequestId, 'V003')
 
-      const data = await getLeaveRequestList(1, 50)
+      const data = await getLeaveRequestList(1, 30)
 
       setVacationData(data.items.filter((item) => item.approvalStatusCode === 'V001').slice(0, 5))
     } catch (error) {


### PR DESCRIPTION
## 📌 개요

-관리자용 대시보드 휴가 신청 내역 size 축소

## 💻 작업 사항

- size:100 -> 30 으로 축소하여 응답 최적화

## 📸 스크린샷 (선택)


  
## 📎 참고 사항 (선택)


  
## 💡 관련 Issue

Closes #

## ✅ 체크리스트

- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
