### PR TITLE
[Fix] MR-16_공지사항 관리 페이지 필터링

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -6,6 +6,7 @@
       "name": "final-project-team1",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
+        "@tanstack/react-query": "^5.100.10",
         "axios": "^1.15.2",
         "date-fns": "^4.1.0",
         "dompurify": "^3.4.2",
@@ -165,6 +166,10 @@
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.7", "", {}, "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA=="],
 
     "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
+
+    "@tanstack/query-core": ["@tanstack/query-core@5.100.10", "", {}, "sha512-8UR0yJR+GiQ40m3lPhUr0xbfAupe6GSQiksSBSa9SM2NjezFyxXCIA69/lz8cSoNKZLrw1/PktIyQBJcVeMi3w=="],
+
+    "@tanstack/react-query": ["@tanstack/react-query@5.100.10", "", { "dependencies": { "@tanstack/query-core": "5.100.10" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-FLaZf2RCrA/Zgp4aiu5tG3TyasTRO7aZ99skxQpr3Hg/zXOhu6yq5FZCYQ/tRaJtM9ylnoK8tFK7PolXQadv6Q=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@tanstack/react-query": "^5.100.10",
     "axios": "^1.15.2",
     "date-fns": "^4.1.0",
     "dompurify": "^3.4.2",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,11 +1,17 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { RouterProvider } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
 import { router } from './routes'
 import './styles/theme/theme.css'
 
+const queryClient = new QueryClient()
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <RouterProvider router={router} />
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
   </React.StrictMode>,
 )

--- a/frontend/src/pages/admin/notice/NoticeListPage.tsx
+++ b/frontend/src/pages/admin/notice/NoticeListPage.tsx
@@ -1,7 +1,8 @@
 // 외부 라이브러리
-import { useEffect, useMemo, useState } from 'react'
+import { useState } from 'react'
 import { FileText, Check } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 // 공통 컴포넌트
 import { Button } from '@/components'
@@ -38,10 +39,13 @@ type NoticeApiItem = {
   openStatusName: string
 }
 
-export default function NoticeListPage() {
-  /** 전체 공지사항 목록 */
-  const [data, setData] = useState<NoticeApiItem[]>([])
+/** 공지사항 목록 API 응답 구조 */
+type NoticeListResponse = {
+  items: NoticeApiItem[]
+  totalCount: number
+}
 
+export default function NoticeListPage() {
   /** 검색어 입력값 */
   const [keyword, setKeyword] = useState('')
 
@@ -58,11 +62,11 @@ export default function NoticeListPage() {
   const [open, setOpen] = useState(false)
   const [modalMessage, setModalMessage] = useState('')
 
-  /** 로딩 상태 */
-  const [isLoading, setIsLoading] = useState(false)
-
   /** 라우팅 이동 */
   const navigate = useNavigate()
+
+  /** React Query 캐시 제어 */
+  const queryClient = useQueryClient()
 
   /** 기본 alert 대신 공통 모달 열기 */
   const showAlert = (message: string) => {
@@ -70,36 +74,45 @@ export default function NoticeListPage() {
     setOpen(true)
   }
 
-  /** 공지사항 목록 조회 */
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        setIsLoading(true)
+  /**
+   * 공지사항 목록 조회
+   * searchKeyword, currentPage가 바뀔 때마다 API 재호출
+   */
+  const {
+    data: noticeResponse,
+    isLoading,
+    isFetching,
+    isError,
+  } = useQuery<NoticeListResponse>({
+    queryKey: ['notices', searchKeyword, currentPage],
+    queryFn: () =>
+      getRecentNoticeRequests({
+        keyword: searchKeyword,
+        page: currentPage,
+        size: PAGE_SIZE,
+      }),
+  })
 
-        const result = await getRecentNoticeRequests()
-        setData(result)
-      } catch (e) {
-        console.error('데이터 조회 실패:', e)
-        showAlert('데이터를 불러오는데 실패했습니다.')
-      } finally {
-        setIsLoading(false)
-      }
-    }
+  /** 서버에서 받은 공지사항 목록 */
+  const notices = noticeResponse?.items ?? []
 
-    fetchData()
-  }, [])
+  /** 서버에서 받은 전체 개수 */
+  const totalCount = noticeResponse?.totalCount ?? 0
+
+  /** 전체 페이지 수 */
+  const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE))
 
   /** 요약 카드 데이터 */
   const noticeSummaryCards: SummaryCard[] = [
     {
       label: '전체 공지',
-      count: data.length,
+      count: totalCount,
       color: 'orange',
       icon: <FileText size={20} />,
     },
     {
       label: '공개 중',
-      count: data.filter((notice) => notice.isOpen).length,
+      count: notices.filter((notice) => notice.isOpen).length,
       color: 'green',
       icon: <Check size={20} />,
     },
@@ -112,9 +125,12 @@ export default function NoticeListPage() {
     )
   }
 
-  /** 공개 / 비공개 상태 변경 */
-  const handleTogglePublic = async (noticeId: number, value: boolean) => {
-    try {
+  /**
+   * 공개 / 비공개 상태 변경 mutation
+   * 상태 변경 성공 후 목록을 다시 조회함
+   */
+  const togglePublicMutation = useMutation({
+    mutationFn: async ({ noticeId, value }: { noticeId: number; value: boolean }) => {
       const detail = await getNoticeDetail(noticeId)
 
       await updateNotice(noticeId, {
@@ -123,55 +139,75 @@ export default function NoticeListPage() {
         isOpen: value,
       })
 
-      setData((prev) =>
-        prev.map((item) =>
-          item.noticeId === noticeId
-            ? {
-                ...item,
-                isOpen: value,
-                openStatusName: value ? '공개' : '비공개',
-              }
-            : item,
-        ),
-      )
+      return value
+    },
+    onSuccess: (value) => {
+      queryClient.invalidateQueries({
+        queryKey: ['notices'],
+      })
 
       setModalMessage(value ? '공개되었습니다.' : '비공개되었습니다.')
       setOpen(true)
-    } catch (e) {
+    },
+    onError: (e) => {
       console.error('공개 상태 변경 실패:', e)
       showAlert('공개 상태 변경 실패')
-    }
+    },
+  })
+
+  /** 공개 / 비공개 상태 변경 */
+  const handleTogglePublic = (noticeId: number, value: boolean) => {
+    togglePublicMutation.mutate({
+      noticeId,
+      value,
+    })
   }
 
-  /** 검색 */
+  /**
+   * 검색
+   * keyword: input에 입력 중인 값
+   * searchKeyword: 실제 API 검색에 사용하는 값
+   */
   const handleSearch = () => {
     setSearchKeyword(keyword)
     setCurrentPage(1)
     setSelectedIds([])
   }
 
-  /** 선택 삭제 */
-  const handleDelete = async () => {
-    if (selectedIds.length === 0) {
-      setModalMessage('삭제할 공지사항을 선택해주세요.')
-      setOpen(true)
-      return
-    }
-
-    try {
-      await Promise.all(selectedIds.map((noticeId) => deleteNotice(noticeId)))
-
-      setData((prev) => prev.filter((notice) => !selectedIds.includes(notice.noticeId)))
+  /**
+   * 선택 삭제 mutation
+   * 삭제 성공 후 목록을 다시 조회함
+   */
+  const deleteMutation = useMutation({
+    mutationFn: async (ids: number[]) => {
+      await Promise.all(ids.map((noticeId) => deleteNotice(noticeId)))
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['notices'],
+      })
 
       setSelectedIds([])
       setCurrentPage(1)
 
       setModalMessage('삭제되었습니다.')
       setOpen(true)
-    } catch (e) {
+    },
+    onError: (e) => {
       console.error('삭제 실패:', e)
       showAlert('삭제에 실패했습니다.')
+    },
+  })
+
+  /** 선택 삭제 */
+  const handleDelete = () => {
+    if (selectedIds.length === 0) {
+      setModalMessage('삭제할 공지사항을 선택해주세요.')
+      setOpen(true)
+      return
     }
+
+    deleteMutation.mutate(selectedIds)
   }
 
   /** 등록 */
@@ -179,29 +215,14 @@ export default function NoticeListPage() {
     navigate('/admin/notice/create')
   }
 
-  /** 검색어에 맞는 공지사항 목록 + 작성일 최신순 정렬 */
-  const filteredNotices = useMemo(() => {
-    return [...data]
-      .filter((notice) => notice.title.includes(searchKeyword))
-      .sort((a, b) => new Date(b.createdDate).getTime() - new Date(a.createdDate).getTime())
-  }, [data, searchKeyword])
+  /**
+   * 현재 페이지에 보여줄 공지사항 목록 */
+  const pagedNotices = notices.map((notice, index) => ({
+    ...notice,
 
-  /** 전체 페이지 수 */
-  const totalPages = Math.max(1, Math.ceil(filteredNotices.length / PAGE_SIZE))
-
-  /** 현재 페이지에 보여줄 공지사항 목록 */
-  const pagedNotices = useMemo(() => {
-    const start = (currentPage - 1) * PAGE_SIZE
-    const end = start + PAGE_SIZE
-
-    return filteredNotices.slice(start, end).map((notice, index) => ({
-      ...notice,
-
-      // 서버에서 내려오는 displayNo 대신
-      // 화면 기준으로 1, 2, 3... 다시 번호를 붙임
-      displayNo: start + index + 1,
-    }))
-  }, [filteredNotices, currentPage])
+    // 화면 기준 번호
+    displayNo: (currentPage - 1) * PAGE_SIZE + index + 1,
+  }))
 
   /** 테이블 컬럼 */
   const noticeColumns: TableColumn<NoticeApiItem>[] = [
@@ -270,6 +291,9 @@ export default function NoticeListPage() {
     },
   ]
 
+  /** 로딩 표시 여부 */
+  const showLoading = isLoading || isFetching
+
   return (
     <AdminLayout>
       <div className={S.page}>
@@ -288,7 +312,7 @@ export default function NoticeListPage() {
             />
 
             <div className={S.table_box}>
-              {isLoading ? (
+              {showLoading ? (
                 <div className={S.skeletonWrapper}>
                   <TableSkeleton
                     columns={[
@@ -301,6 +325,8 @@ export default function NoticeListPage() {
                     rows={PAGE_SIZE}
                   />
                 </div>
+              ) : isError ? (
+                <div className={S.empty}>데이터를 불러오는데 실패했습니다.</div>
               ) : (
                 <Table columns={noticeColumns} data={pagedNotices} />
               )}
@@ -308,15 +334,17 @@ export default function NoticeListPage() {
 
             <div className={S.table_footer}>
               <span>
-                총 {filteredNotices.length}건 중{' '}
-                {filteredNotices.length === 0 ? 0 : (currentPage - 1) * PAGE_SIZE + 1} -{' '}
-                {Math.min(currentPage * PAGE_SIZE, filteredNotices.length)}건 표시
+                총 {totalCount}건 중 {totalCount === 0 ? 0 : (currentPage - 1) * PAGE_SIZE + 1} -{' '}
+                {Math.min(currentPage * PAGE_SIZE, totalCount)}건 표시
               </span>
 
               <Pagination
                 currentPage={currentPage}
                 totalPages={totalPages}
-                onPageChange={setCurrentPage}
+                onPageChange={(page) => {
+                  setCurrentPage(page)
+                  setSelectedIds([])
+                }}
               />
             </div>
           </section>

--- a/frontend/src/pages/admin/notice/api/noticeApi.ts
+++ b/frontend/src/pages/admin/notice/api/noticeApi.ts
@@ -1,15 +1,51 @@
 import { api } from '@/api/axios'
 
-// 리스트 조회
-export async function getRecentNoticeRequests() {
+/** 공지사항 목록 조회 요청 파라미터 */
+export type NoticeListParams = {
+  keyword?: string
+  page: number
+  size: number
+}
+
+/** 서버에서 내려오는 공지사항 데이터 구조 */
+export type NoticeApiItem = {
+  noticeId: number
+  displayNo: number
+  title: string
+  createdDate: string
+  isOpen: boolean
+  openStatusName: string
+}
+
+/** 공지사항 목록 조회 응답 구조 */
+export type NoticeListResponse = {
+  items: NoticeApiItem[]
+  totalCount: number
+}
+
+/**
+ * 리스트 조회
+ *
+ * 기존:
+ * page: 1, size: 100 고정
+ *
+ * 변경:
+ * 화면에서 넘긴 keyword, page, size 기준으로 조회
+ */
+export async function getRecentNoticeRequests({
+  keyword = '',
+  page,
+  size,
+}: NoticeListParams): Promise<NoticeListResponse> {
   const res = await api.get('/api/admin/notices', {
     params: {
-      page: 1,
-      size: 100,
+      keyword,
+      page,
+      size,
     },
   })
 
-  return res.data.data.items
+  return res.data.data
 }
 
 // 삭제
@@ -33,15 +69,12 @@ export async function updateNotice(
     isOpen: boolean
   },
 ) {
-  return api.put(`/api/admin/notices/${noticeId}`, payload)
+  const res = await api.put(`/api/admin/notices/${noticeId}`, payload)
+  return res.data.data
 }
 
-
 // 리스트 등록
-export async function createNotice(payload: {
-  title: string
-  content: string
-}) {
+export async function createNotice(payload: { title: string; content: string }) {
   const res = await api.post('/api/admin/notices', payload)
   return res.data
 }


### PR DESCRIPTION
## 📌 개요
- 공지사항 목록 검색시 API 재호출

## 💻 작업 사항
- 공지사항 목록 검색시 API 요청 상태를 TanStack Query 기반으로 관리하도록 변경
- TanStack Query를 도입하여 서버 데이터 요청 상태를 관리하도록 수정
- `main.tsx`에 `QueryClientProvider`를 추가해 앱 전역에서 Query 기능을 사용할 수 있도록 설정

## 📎 참고 사항
- TanStack Query 사용을 위해 `main.tsx`에 `QueryClientProvider`를 추가했습니다.  
- 앱 전체에서 `useQuery`, `useMutation`을 사용할 수 있도록 전역 설정한 부분입니다.
  
## 💡 관련 Issue
Closes #196 

## ✅ 체크리스트

- [X] 관련 이슈를 연결했습니다. (Closes #)
- [X] 불필요한 console.log를 제거했습니다.
- [X] 사용하지 않는 코드/파일을 정리했습니다.
- [X] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [X] 기능이 정상 동작하는지 확인했습니다.
