### PR TITLE
[Fix] API 요청 객체 axiosInstance로 통일

### DIFF
--- a/frontend/src/pages/admin/attendance/api/attendanceApi.ts
+++ b/frontend/src/pages/admin/attendance/api/attendanceApi.ts
@@ -1,4 +1,4 @@
-import { api } from '@/api/axios'
+import { axiosInstance } from '@/api/axios'
 
 export type AttendanceApiItem = {
   attendanceId: number
@@ -25,7 +25,7 @@ export async function getAttendanceList({
   page = 1,
   size = 12,
 }: GetAttendanceListParams = {}) {
-  const res = await api.get('/api/admin/attendances', {
+  const res = await axiosInstance.get('/api/admin/attendances', {
     params: {
       page,
       size,

--- a/frontend/src/pages/admin/leave/api/leaveApi.ts
+++ b/frontend/src/pages/admin/leave/api/leaveApi.ts
@@ -1,7 +1,7 @@
-import { api } from '@/api/axios'
+import { axiosInstance } from '@/api/axios'
 
 export async function getRecentLeaveRequests() {
-  const res = await api.get('/api/admin/leave-requests', {
+  const res = await axiosInstance.get('/api/admin/leave-requests', {
     params: {
       page: 1,
       size: 100,
@@ -10,8 +10,9 @@ export async function getRecentLeaveRequests() {
 
   return res.data.data.items
 }
+
 export async function updateLeaveRequestStatus(leaveRequestId: number, statusCode: string) {
-  const res = await api.patch(`/api/admin/leave-requests/${leaveRequestId}/status`, {
+  const res = await axiosInstance.patch(`/api/admin/leave-requests/${leaveRequestId}/status`, {
     approvalStatusCode: statusCode,
   })
 

--- a/frontend/src/pages/admin/notice/api/noticeApi.ts
+++ b/frontend/src/pages/admin/notice/api/noticeApi.ts
@@ -1,4 +1,4 @@
-import { api } from '@/api/axios'
+import { axiosInstance } from '@/api/axios'
 
 /** 공지사항 목록 조회 요청 파라미터 */
 export type NoticeListParams = {
@@ -37,7 +37,7 @@ export async function getRecentNoticeRequests({
   page,
   size,
 }: NoticeListParams): Promise<NoticeListResponse> {
-  const res = await api.get('/api/admin/notices', {
+  const res = await axiosInstance.get('/api/admin/notices', {
     params: {
       keyword,
       page,
@@ -50,13 +50,13 @@ export async function getRecentNoticeRequests({
 
 // 삭제
 export async function deleteNotice(noticeId: number) {
-  const res = await api.delete(`/api/admin/notices/${noticeId}`)
+  const res = await axiosInstance.delete(`/api/admin/notices/${noticeId}`)
   return res.data.data
 }
 
 // 상세 조회
 export async function getNoticeDetail(noticeId: number) {
-  const res = await api.get(`/api/admin/notices/${noticeId}`)
+  const res = await axiosInstance.get(`/api/admin/notices/${noticeId}`)
   return res.data.data
 }
 
@@ -69,12 +69,12 @@ export async function updateNotice(
     isOpen: boolean
   },
 ) {
-  const res = await api.put(`/api/admin/notices/${noticeId}`, payload)
+  const res = await axiosInstance.put(`/api/admin/notices/${noticeId}`, payload)
   return res.data.data
 }
 
 // 리스트 등록
 export async function createNotice(payload: { title: string; content: string }) {
-  const res = await api.post('/api/admin/notices', payload)
+  const res = await axiosInstance.post('/api/admin/notices', payload)
   return res.data
 }


### PR DESCRIPTION
## 📌 개요
- API 요청 객체 axiosInstance로 통일이 안됨

## 💻 작업 사항
- 공지/휴가/출석 페이지 API 요청 객체 axiosInstance로 통일

## 💡 관련 Issue
Closes #205 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #)
- [x] 불필요한 console.log를 제거했습니다.
- [x] 사용하지 않는 코드/파일을 정리했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
