### PR TITLE
[Fix] 휴가 관리 페이지 목록 조회 속도 개선

### DIFF
--- a/frontend/src/pages/admin/leave/LeaveApprovePage.tsx
+++ b/frontend/src/pages/admin/leave/LeaveApprovePage.tsx
@@ -1,5 +1,5 @@
 // 외부 라이브러리
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { FileText, Check, X } from 'lucide-react'
 
 // 공통 컴포넌트
@@ -51,6 +51,20 @@ const statusMap: Record<string, TabType> = {
   반려: 'rejected',
 }
 
+/** 상태 코드 매핑 */
+const statusCodeMap: Record<TabType, string> = {
+  pending: 'V001',
+  approved: 'V002',
+  rejected: 'V003',
+}
+
+/** 상태 이름 매핑 */
+const statusNameMap: Record<TabType, string> = {
+  pending: '승인 대기',
+  approved: '승인 완료',
+  rejected: '반려',
+}
+
 export default function LeaveApprovePage() {
   /** 전체 휴가 신청 목록 */
   const [data, setData] = useState<LeaveApiItem[]>([])
@@ -61,12 +75,15 @@ export default function LeaveApprovePage() {
   /** 현재 페이지 번호 */
   const [currentPage, setCurrentPage] = useState(1)
 
+  /** 목록 최초 로딩 */
+  const [isLoading, setIsLoading] = useState(false)
+
+  /** 승인/반려 처리 중인 행 ID */
+  const [processingId, setProcessingId] = useState<number | null>(null)
+
   /** 승인 및 반려 처리 팝업 */
   const [open, setOpen] = useState(false)
   const [modalMessage, setModalMessage] = useState('')
-
-  
-  const [isLoading, setIsLoading] = useState(false)
 
   /** 휴가 신청 목록 조회 */
   useEffect(() => {
@@ -78,7 +95,8 @@ export default function LeaveApprovePage() {
         setData(result)
       } catch (e: unknown) {
         console.error('데이터 조회 실패:', e)
-        alert('데이터를 불러오는데 실패했습니다.')
+        setModalMessage('데이터를 불러오는데 실패했습니다.')
+        setOpen(true)
       } finally {
         setIsLoading(false)
       }
@@ -94,162 +112,180 @@ export default function LeaveApprovePage() {
   }
 
   /** 승인 / 반려 상태 변경 */
-  const handleUpdateStatus = async (leaveRequestId: number, nextStatus: TabType) => {
-    try {
-      const statusCodeMap: Record<TabType, string> = {
-        pending: 'V001',
-        approved: 'V002',
-        rejected: 'V003',
+  const handleUpdateStatus = useCallback(
+    async (leaveRequestId: number, nextStatus: TabType) => {
+      if (processingId !== null) return
+
+      setProcessingId(leaveRequestId)
+
+      try {
+        await updateLeaveRequestStatus(leaveRequestId, statusCodeMap[nextStatus])
+
+        setData((prev) =>
+          prev.map((item) =>
+            item.leaveRequestId === leaveRequestId
+              ? {
+                  ...item,
+                  approvalStatusCode: statusCodeMap[nextStatus],
+                  approvalStatusName: statusNameMap[nextStatus],
+                }
+              : item,
+          ),
+        )
+
+        setModalMessage(nextStatus === 'approved' ? '승인 되었습니다.' : '반려 되었습니다.')
+        setOpen(true)
+      } catch (e: unknown) {
+        console.error('상태 변경 실패:', e)
+        setModalMessage(e instanceof Error ? e.message : '처리에 실패했습니다.')
+        setOpen(true)
+      } finally {
+        setProcessingId(null)
       }
+    },
+    [processingId],
+  )
 
-      const statusNameMap: Record<TabType, string> = {
-        pending: '승인 대기',
-        approved: '승인 완료',
-        rejected: '반려',
-      }
-
-      await updateLeaveRequestStatus(leaveRequestId, statusCodeMap[nextStatus])
-
-      setData((prev) =>
-        prev.map((item) =>
-          item.leaveRequestId === leaveRequestId
-            ? {
-                ...item,
-                approvalStatusCode: statusCodeMap[nextStatus],
-                approvalStatusName: statusNameMap[nextStatus],
-              }
-            : item,
-        ),
-      )
-
-      setModalMessage(nextStatus === 'approved' ? '승인 되었습니다.' : '반려 되었습니다.')
-      setOpen(true)
-    } catch (e: unknown) {
-      console.error('상태 변경 실패:', e)
-
-      if (e instanceof Error) {
-        alert(e.message)
-      } else {
-        alert('처리에 실패했습니다.')
-      }
-    } finally {
-      setIsLoading(false)
+  /**
+   * 상태별 데이터 묶음
+   *
+   * 기존에는 pending, approved, rejected 개수를 구할 때마다
+   * data.filter()를 여러 번 실행했음.
+   *
+   * useMemo로 data가 바뀔 때만 다시 계산하게 개선.
+   */
+  const groupedData = useMemo(() => {
+    const result: Record<TabType, LeaveApiItem[]> = {
+      pending: [],
+      approved: [],
+      rejected: [],
     }
-  }
 
-  /** 상태별 신청 개수 */
-  const pendingCount = data.filter(
-    (item) => statusMap[item.approvalStatusName] === 'pending',
-  ).length
-  const approvedCount = data.filter(
-    (item) => statusMap[item.approvalStatusName] === 'approved',
-  ).length
-  const rejectedCount = data.filter(
-    (item) => statusMap[item.approvalStatusName] === 'rejected',
-  ).length
+    data.forEach((item) => {
+      const tab = statusMap[item.approvalStatusName]
 
-  /** 상단 요약 카드 데이터 */
-  const noticeSummaryCards: SummaryCard[] = [
-    {
-      label: '승인 대기',
-      count: pendingCount,
-      color: 'orange',
-      icon: <FileText size={20} />,
-    },
-    {
-      label: '승인 완료',
-      count: approvedCount,
-      color: 'green',
-      icon: <Check size={20} />,
-    },
-    {
-      label: '반려 내역',
-      count: rejectedCount,
-      color: 'red',
-      icon: <X size={20} />,
-    },
-  ]
+      if (tab) {
+        result[tab].push(item)
+      }
+    })
+
+    return result
+  }, [data])
 
   /** 현재 탭에 해당하는 데이터 */
-  const currentData = data.filter((item) => statusMap[item.approvalStatusName] === activeTab)
+  const currentData = groupedData[activeTab]
 
   /** 전체 페이지 수 */
   const totalPages = Math.max(1, Math.ceil(currentData.length / PAGE_SIZE))
 
   /** 현재 페이지에 보여줄 데이터 */
-  const pagedData = currentData.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE)
+  const pagedData = useMemo(() => {
+    const startIndex = (currentPage - 1) * PAGE_SIZE
+    const endIndex = currentPage * PAGE_SIZE
 
-  /** 처리 컬럼 */
-  const actionColumn: TableColumn<LeaveApiItem> = {
-    key: 'action',
-    header: activeTab === 'pending' ? '처리' : '처리내역',
-    render: (row) => {
-      if (activeTab === 'pending') {
-        return (
-          <div className={S.actionBox}>
-            <Button
-              type="button"
-              variant="active"
-              onClick={() => handleUpdateStatus(row.leaveRequestId, 'approved')}
-            >
-              <Check size={16} /> 승인
-            </Button>
+    return currentData.slice(startIndex, endIndex)
+  }, [currentData, currentPage])
 
-            <Button
-              type="button"
-              variant="inactive"
-              onClick={() => handleUpdateStatus(row.leaveRequestId, 'rejected')}
-            >
-              <X size={16} /> 반려
-            </Button>
-          </div>
-        )
-      }
-
-      if (activeTab === 'approved') {
-        return (
-          <Button type="button" variant="active" disabled>
-            <Check size={16} /> 승인
-          </Button>
-        )
-      }
-
-      return (
-        <Button type="button" variant="inactive" disabled>
-          <X size={16} /> 반려
-        </Button>
-      )
-    },
-  }
+  /** 상단 요약 카드 데이터 */
+  const noticeSummaryCards: SummaryCard[] = useMemo(
+    () => [
+      {
+        label: '승인 대기',
+        count: groupedData.pending.length,
+        color: 'orange',
+        icon: <FileText size={20} />,
+      },
+      {
+        label: '승인 완료',
+        count: groupedData.approved.length,
+        color: 'green',
+        icon: <Check size={20} />,
+      },
+      {
+        label: '반려 내역',
+        count: groupedData.rejected.length,
+        color: 'red',
+        icon: <X size={20} />,
+      },
+    ],
+    [groupedData],
+  )
 
   /** 테이블 컬럼 */
-  const vacationColumns: TableColumn<LeaveApiItem>[] = [
-    {
-      key: 'studentName',
-      header: '신청자',
-      render: (row) => (
-        <div className={S.nameBox}>
-          <span className={S.tit}>{row.studentName}</span>
-        </div>
-      ),
-    },
-    { key: 'studentId', header: '학번' },
-    {
-      key: 'leaveTypeName',
-      header: '휴가종류',
-      render: (row) => {
-        const vacation = vacationTypeMap[row.leaveTypeName] ?? vacationTypeMap['개인사유']
-
-        return <span className={`${S.statusBadge} ${vacation.className}`}>{vacation.label}</span>
+  const vacationColumns: TableColumn<LeaveApiItem>[] = useMemo(
+    () => [
+      {
+        key: 'studentName',
+        header: '신청자',
+        render: (row) => (
+          <div className={S.nameBox}>
+            <span className={S.tit}>{row.studentName}</span>
+          </div>
+        ),
       },
-    },
-    {
-      key: 'startDate',
-      header: '기간',
-      render: (row) => `${row.startDate} - ${row.endDate}`,
-    },
-    actionColumn,
-  ]
+      { key: 'studentId', header: '학번' },
+      {
+        key: 'leaveTypeName',
+        header: '휴가종류',
+        render: (row) => {
+          const vacation = vacationTypeMap[row.leaveTypeName] ?? vacationTypeMap['개인사유']
+
+          return <span className={`${S.statusBadge} ${vacation.className}`}>{vacation.label}</span>
+        },
+      },
+      {
+        key: 'startDate',
+        header: '기간',
+        render: (row) => `${row.startDate} - ${row.endDate}`,
+      },
+      {
+        key: 'action',
+        header: activeTab === 'pending' ? '처리' : '처리내역',
+        render: (row) => {
+          const isProcessing = processingId === row.leaveRequestId
+
+          if (activeTab === 'pending') {
+            return (
+              <div className={S.actionBox}>
+                <Button
+                  type="button"
+                  variant="active"
+                  disabled={processingId !== null}
+                  onClick={() => handleUpdateStatus(row.leaveRequestId, 'approved')}
+                >
+                  <Check size={16} /> {isProcessing ? '처리중' : '승인'}
+                </Button>
+
+                <Button
+                  type="button"
+                  variant="inactive"
+                  disabled={processingId !== null}
+                  onClick={() => handleUpdateStatus(row.leaveRequestId, 'rejected')}
+                >
+                  <X size={16} /> {isProcessing ? '처리중' : '반려'}
+                </Button>
+              </div>
+            )
+          }
+
+          if (activeTab === 'approved') {
+            return (
+              <Button type="button" variant="active" disabled>
+                <Check size={16} /> 승인
+              </Button>
+            )
+          }
+
+          return (
+            <Button type="button" variant="inactive" disabled>
+              <X size={16} /> 반려
+            </Button>
+          )
+        },
+      },
+    ],
+    [activeTab, processingId, handleUpdateStatus],
+  )
 
   return (
     <AdminLayout>
@@ -299,6 +335,7 @@ export default function LeaveApprovePage() {
           </section>
         </main>
       </div>
+
       <Modal
         isOpen={open}
         onClose={() => setOpen(false)}


### PR DESCRIPTION
## 📌 개요
- 휴가 관리 페이지 목록 조회 속도 개선

## 💻 작업 사항
- 휴가 관리 페이지 렌더링 연산 최적화
- 상태별 데이터 필터링 및 페이지 데이터 계산에 `useMemo` 적용
- 승인/반려 처리 함수에 `useCallback` 적용
- 처리 중 버튼 중복 클릭 방지 로직 추가
- 에러/안내 메시지를 공통 Modal로 표시하도록 수정

  
## 💡 관련 Issue
Closes #208 

## ✅ 체크리스트
- [x] 관련 이슈를 연결했습니다. (Closes #)
- [x] 불필요한 console.log를 제거했습니다.
- [x] 사용하지 않는 코드/파일을 정리했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
